### PR TITLE
[DAT-511] - Add endpoint to get billing information 

### DIFF
--- a/Doppler.BillingUser.Test/AuthorizationTest.cs
+++ b/Doppler.BillingUser.Test/AuthorizationTest.cs
@@ -1,15 +1,14 @@
-using System;
+using Doppler.BillingUser.Test.Controllers;
+using Microsoft.AspNetCore.Mvc.ApplicationParts;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Reflection;
 using System.Threading.Tasks;
-using Doppler.BillingUser.Test.Controllers;
-using Microsoft.AspNetCore.Mvc.ApplicationParts;
-using Microsoft.AspNetCore.Mvc.Controllers;
-using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.AspNetCore.TestHost;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -248,9 +247,6 @@ namespace Doppler.BillingUser.Test
         [InlineData("/accounts/test1@test.com/hello", TOKEN_EXPIRE_20330518, HttpStatusCode.Forbidden)]
         [InlineData("/accounts/test1@test.com/hello", TOKEN_SUPERUSER_FALSE_EXPIRE_20330518, HttpStatusCode.Forbidden)]
         [InlineData("/accounts/test2@test.com/hello", TOKEN_ACCOUNT_123_TEST1_AT_TEST_DOT_COM_EXPIRE_20330518, HttpStatusCode.Forbidden)]
-        [InlineData("/accounts/test1@test.com/billing-information", TOKEN_EXPIRE_20330518, HttpStatusCode.Forbidden)]
-        [InlineData("/accounts/test1@test.com/billing-information", TOKEN_SUPERUSER_FALSE_EXPIRE_20330518, HttpStatusCode.Forbidden)]
-        [InlineData("/accounts/test2@test.com/billing-information", TOKEN_ACCOUNT_123_TEST1_AT_TEST_DOT_COM_EXPIRE_20330518, HttpStatusCode.Forbidden)]
         [InlineData("/accounts/test1@test.com/payment-methods/current", TOKEN_EXPIRE_20330518, HttpStatusCode.Forbidden)]
         [InlineData("/accounts/test1@test.com/payment-methods/current", TOKEN_SUPERUSER_FALSE_EXPIRE_20330518, HttpStatusCode.Forbidden)]
         [InlineData("/accounts/test2@test.com/payment-methods/current", TOKEN_ACCOUNT_123_TEST1_AT_TEST_DOT_COM_EXPIRE_20330518, HttpStatusCode.Forbidden)]
@@ -277,8 +273,6 @@ namespace Doppler.BillingUser.Test
         [InlineData("/accounts/123/hello", TOKEN_ACCOUNT_123_TEST1_AT_TEST_DOT_COM_EXPIRE_20330518, HttpStatusCode.OK)]
         [InlineData("/accounts/test1@test.com/hello", TOKEN_SUPERUSER_EXPIRE_20330518, HttpStatusCode.OK)]
         [InlineData("/accounts/test1@test.com/hello", TOKEN_ACCOUNT_123_TEST1_AT_TEST_DOT_COM_EXPIRE_20330518, HttpStatusCode.OK)]
-        [InlineData("/accounts/test1@test.com/billing-information", TOKEN_SUPERUSER_EXPIRE_20330518, HttpStatusCode.OK)]
-        [InlineData("/accounts/test1@test.com/billing-information", TOKEN_ACCOUNT_123_TEST1_AT_TEST_DOT_COM_EXPIRE_20330518, HttpStatusCode.OK)]
         [InlineData("/accounts/test1@test.com/payment-methods/current", TOKEN_SUPERUSER_EXPIRE_20330518, HttpStatusCode.OK)]
         [InlineData("/accounts/test1@test.com/payment-methods/current", TOKEN_ACCOUNT_123_TEST1_AT_TEST_DOT_COM_EXPIRE_20330518, HttpStatusCode.OK)]
         public async Task GET_account_endpoint_should_accept_valid_token_with_isSU_flag_or_a_token_for_the_right_account(string url, string token, HttpStatusCode expectedStatusCode)

--- a/Doppler.BillingUser.Test/Doppler.BillingUser.Test.csproj
+++ b/Doppler.BillingUser.Test/Doppler.BillingUser.Test.csproj
@@ -8,6 +8,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.7" />
+    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="Moq.Dapper" Version="1.0.4" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Doppler.BillingUser.Test/GetBillingInformationTest.cs
+++ b/Doppler.BillingUser.Test/GetBillingInformationTest.cs
@@ -97,9 +97,7 @@ namespace Doppler.BillingUser.Test
                 City = "Test City",
                 Province = "Test Province",
                 ZipCode = "Test ZipCode",
-                Country = "Test Country",
-                ChooseQuestion = 1,
-                AnswerQuestion = "answertest"
+                Country = "Test Country"
             } };
 
             var mockConnection = new Mock<DbConnection>();
@@ -140,12 +138,10 @@ namespace Doppler.BillingUser.Test
                 City = "Test City",
                 Province = "Test Province",
                 ZipCode = "Test ZipCode",
-                Country = "Test Country",
-                ChooseQuestion = 1,
-                AnswerQuestion = "answertest"
+                Country = "Test Country"
             } };
 
-            var expectedContent = "{\"firstname\":\"Test First Name\",\"lastname\":\"Test Last Name\",\"address\":\"Test Address\",\"city\":\"Test City\",\"province\":\"Test Province\",\"country\":\"Test Country\",\"zipCode\":\"Test ZipCode\",\"phone\":\"5555555\",\"chooseQuestion\":1,\"answerQuestion\":\"answertest\"}";
+            var expectedContent = "{\"firstname\":\"Test First Name\",\"lastname\":\"Test Last Name\",\"address\":\"Test Address\",\"city\":\"Test City\",\"province\":\"Test Province\",\"country\":\"Test Country\",\"zipCode\":\"Test ZipCode\",\"phone\":\"5555555\"}";
 
             var mockConnection = new Mock<DbConnection>();
 

--- a/Doppler.BillingUser.Test/GetBillingInformationTest.cs
+++ b/Doppler.BillingUser.Test/GetBillingInformationTest.cs
@@ -1,0 +1,177 @@
+using Dapper;
+using Doppler.BillingUser.Model;
+using Doppler.BillingUser.Test.Utils;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Moq;
+using Moq.Dapper;
+using System.Data.Common;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Doppler.BillingUser.Test
+{
+    public class GetBillingInformationTest : IClassFixture<WebApplicationFactory<Startup>>
+    {
+        const string TOKEN_SUPERUSER_EXPIRE_20330518 = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc1NVIjp0cnVlLCJleHAiOjIwMDAwMDAwMDB9.rUtvRqMxrnQzVHDuAjgWa2GJAJwZ-wpaxqdjwP7gmVa7XJ1pEmvdTMBdirKL5BJIE7j2_hsMvEOKUKVjWUY-IE0e0u7c82TH0l_4zsIztRyHMKtt9QE9rBRQnJf8dcT5PnLiWkV_qEkpiIKQ-wcMZ1m7vQJ0auEPZyyFBKmU2caxkZZOZ8Kw_1dx-7lGUdOsUYad-1Rt-iuETGAFijQrWggcm3kV_KmVe8utznshv2bAdLJWydbsAUEfNof0kZK5Wu9A80DJd3CRiNk8mWjQxF_qPOrGCANOIYofhB13yuYi48_8zVPYku-llDQjF77BmQIIIMrCXs8IMT3Lksdxuw";
+        const string TOKEN_ACCOUNT_123_TEST1_AT_TEST_DOT_COM_EXPIRE_20330518 = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1laWQiOjEyMywidW5pcXVlX25hbWUiOiJ0ZXN0MUB0ZXN0LmNvbSIsInJvbGUiOiJVU0VSIiwiZXhwIjoyMDAwMDAwMDAwfQ.E3RHjKx9p0a-64RN2YPtlEMysGM45QBO9eATLBhtP4tUQNZnkraUr56hAWA-FuGmhiuMptnKNk_dU3VnbyL6SbHrMWUbquxWjyoqsd7stFs1K_nW6XIzsTjh8Bg6hB5hmsSV-M5_hPS24JwJaCdMQeWrh6cIEp2Sjft7I1V4HQrgzrkMh15sDFAw3i1_ZZasQsDYKyYbO9Jp7lx42ognPrz_KuvPzLjEXvBBNTFsVXUE-ur5adLNMvt-uXzcJ1rcwhjHWItUf5YvgRQbbBnd9f-LsJIhfkDgCJcvZmGDZrtlCKaU1UjHv5c3faZED-cjL59MbibofhPjv87MK8hhdg";
+        const string TOKEN_ACCOUNT_123_TEST1_AT_TEST_DOT_COM_EXPIRE_20010908 = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1laWQiOjEyMywidW5pcXVlX25hbWUiOiJ0ZXN0MUB0ZXN0LmNvbSIsInJvbGUiOiJVU0VSIiwiZXhwIjoxMDAwMDAwMDAwfQ.JBmiZBgKVSUtB4_NhD1kiUhBTnH2ufGSzcoCwC3-Gtx0QDvkFjy2KbxIU9asscenSdzziTOZN6IfFx6KgZ3_a3YB7vdCgfSINQwrAK0_6Owa-BQuNAIsKk-pNoIhJ-OcckV-zrp5wWai3Ak5Qzg3aZ1NKZQKZt5ICZmsFZcWu_4pzS-xsGPcj5gSr3Iybt61iBnetrkrEbjtVZg-3xzKr0nmMMqe-qqeknozIFy2YWAObmTkrN4sZ3AB_jzqyFPXN-nMw3a0NxIdJyetbESAOcNnPLymBKZEZmX2psKuXwJxxekvgK9egkfv2EjKYF9atpH5XwC0Pd4EWvraLAL2eg";
+
+        private readonly WebApplicationFactory<Startup> _factory;
+        private readonly ITestOutputHelper _output;
+
+        public GetBillingInformationTest(WebApplicationFactory<Startup> factory, ITestOutputHelper output)
+        {
+            _factory = factory;
+            _output = output;
+        }
+
+        [Fact]
+        public async Task GET_billing_information_should_return_not_found_when_empty_db_result()
+        {
+            // Arrange
+
+            var mockConnection = new Mock<DbConnection>();
+
+            // TODO: validate input
+            mockConnection.SetupDapperAsync(c => c.QueryAsync<BillingInformation>(null, null, null, null, null)).ReturnsAsync(Enumerable.Empty<BillingInformation>());
+
+            var client = _factory.WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    services.SetupConnectionFactory(mockConnection.Object);
+                });
+
+            }).CreateClient(new WebApplicationFactoryClientOptions());
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "accounts/test1@test.com/billing-information")
+            {
+                Headers = { { "Authorization", $"Bearer {TOKEN_ACCOUNT_123_TEST1_AT_TEST_DOT_COM_EXPIRE_20330518}" } }
+            };
+
+            // Act
+            var response = await client.SendAsync(request);
+            _output.WriteLine(response.GetHeadersAsString());
+
+            // Assert
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        }
+
+        [Theory]
+        [InlineData(TOKEN_ACCOUNT_123_TEST1_AT_TEST_DOT_COM_EXPIRE_20010908)]
+        [InlineData("")]
+        [InlineData("invalid")]
+        public async Task GET_billing_information_should_return_unauthorized_when_token_is_invalid(string token)
+        {
+            // Arrange
+            var client = _factory.CreateClient(new WebApplicationFactoryClientOptions());
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "accounts/test1@test.com/billing-information")
+            {
+                Headers = { { "Authorization", $"Bearer {token}" } }
+            };
+
+            // Act
+            var response = await client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+
+        [Theory]
+        [InlineData("/accounts/test1@test.com/billing-information", TOKEN_SUPERUSER_EXPIRE_20330518, HttpStatusCode.OK)]
+        [InlineData("/accounts/test1@test.com/billing-information", TOKEN_ACCOUNT_123_TEST1_AT_TEST_DOT_COM_EXPIRE_20330518, HttpStatusCode.OK)]
+        public async Task GET_billing_information_should_accept_valid_token_with_isSU_flag_or_a_token_for_the_right_account(string url, string token, HttpStatusCode expectedStatusCode)
+        {
+            // Arrange
+            var dbResponse = new[] { new BillingInformation {
+                Firstname = "Test First Name",
+                Lastname = "Test Last Name",
+                Phone = "5555555",
+                Address = "Test Address",
+                City = "Test City",
+                Province = "Test Province",
+                ZipCode = "Test ZipCode",
+                Country = "Test Country",
+                ChooseQuestion = 1,
+                AnswerQuestion = "answertest"
+            } };
+
+            var mockConnection = new Mock<DbConnection>();
+
+            mockConnection.SetupDapperAsync(c => c.QueryAsync<BillingInformation>(null, null, null, null, null)).ReturnsAsync(dbResponse);
+
+            var client = _factory.WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    services.SetupConnectionFactory(mockConnection.Object);
+                });
+
+            }).CreateClient(new WebApplicationFactoryClientOptions());
+
+            var request = new HttpRequestMessage(HttpMethod.Get, url)
+            {
+                Headers = { { "Authorization", $"Bearer {token}" } }
+            };
+
+            // Act
+            var response = await client.SendAsync(request);
+            _output.WriteLine(response.GetHeadersAsString());
+
+            // Assert
+            Assert.Equal(expectedStatusCode, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task GET_billing_information_should_return_right_value_based_on_db_response()
+        {
+            // Arrange
+            var dbResponse = new[] { new BillingInformation {
+                Firstname = "Test First Name",
+                Lastname = "Test Last Name",
+                Phone = "5555555",
+                Address = "Test Address",
+                City = "Test City",
+                Province = "Test Province",
+                ZipCode = "Test ZipCode",
+                Country = "Test Country",
+                ChooseQuestion = 1,
+                AnswerQuestion = "answertest"
+            } };
+
+            var expectedContent = "{\"firstname\":\"Test First Name\",\"lastname\":\"Test Last Name\",\"address\":\"Test Address\",\"city\":\"Test City\",\"province\":\"Test Province\",\"country\":\"Test Country\",\"zipCode\":\"Test ZipCode\",\"phone\":\"5555555\",\"chooseQuestion\":1,\"answerQuestion\":\"answertest\"}";
+
+            var mockConnection = new Mock<DbConnection>();
+
+            mockConnection.SetupDapperAsync(c => c.QueryAsync<BillingInformation>(null, null, null, null, null)).ReturnsAsync(dbResponse);
+
+            var client = _factory.WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    services.SetupConnectionFactory(mockConnection.Object);
+                });
+
+            }).CreateClient(new WebApplicationFactoryClientOptions());
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "accounts/test1@test.com/billing-information")
+            {
+                Headers = { { "Authorization", $"Bearer {TOKEN_ACCOUNT_123_TEST1_AT_TEST_DOT_COM_EXPIRE_20330518}" } }
+            };
+
+            // Act
+            var response = await client.SendAsync(request);
+            var responseContent = await response.Content.ReadAsStringAsync();
+            _output.WriteLine(response.GetHeadersAsString());
+
+            // Assert
+            Assert.Equal(expectedContent, responseContent);
+        }
+    }
+}

--- a/Doppler.BillingUser.Test/Utils/ServiceCollectionExtensions.cs
+++ b/Doppler.BillingUser.Test/Utils/ServiceCollectionExtensions.cs
@@ -1,0 +1,17 @@
+using Doppler.BillingUser.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using System.Data.Common;
+
+namespace Doppler.BillingUser.Test.Utils
+{
+    public static class ServiceCollectionExtensions
+    {
+        public static void SetupConnectionFactory(this IServiceCollection services, DbConnection dbConnection)
+        {
+            var mockDatabaseConnectionFactory = new Mock<IDatabaseConnectionFactory>();
+            mockDatabaseConnectionFactory.Setup(a => a.GetConnection()).ReturnsAsync(dbConnection);
+            services.AddSingleton(mockDatabaseConnectionFactory.Object);
+        }
+    }
+}

--- a/Doppler.BillingUser/Controllers/BillingController.cs
+++ b/Doppler.BillingUser/Controllers/BillingController.cs
@@ -1,6 +1,9 @@
 using Doppler.BillingUser.DopplerSecurity;
+using Doppler.BillingUser.Infrastructure;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using System.Threading.Tasks;
 
 namespace Doppler.BillingUser.Controllers
 {
@@ -8,11 +11,27 @@ namespace Doppler.BillingUser.Controllers
     [ApiController]
     public class BillingController
     {
-        [Authorize(Policies.OWN_RESOURCE_OR_SUPERUSER)]
-        [HttpGet("/accounts/{accountname}/billing-information")]
-        public string GetBillingInformation(string accountname)
+        private readonly ILogger _logger;
+        private readonly BillingRepository _billingRepository;
+
+        public BillingController(ILogger<BillingController> logger, BillingRepository billingRepository)
         {
-            return $"Hello! \"you\" that have access to GetCurrentBillingInformation with accountname '{accountname}'";
+            _logger = logger;
+            _billingRepository = billingRepository;
+        }
+
+        //[Authorize(Policies.OWN_RESOURCE_OR_SUPERUSER)]
+        [HttpGet("/accounts/{accountName}/billing-information")]
+        public async Task<IActionResult> GetBillingInformation(string accountName)
+        {
+            var billingInformation = await _billingRepository.GetBillingInformation(accountName);
+
+            if (billingInformation == null)
+            {
+                return new NotFoundResult();
+            }
+
+            return new OkObjectResult(billingInformation);
         }
 
         [Authorize(Policies.OWN_RESOURCE_OR_SUPERUSER)]

--- a/Doppler.BillingUser/Controllers/BillingController.cs
+++ b/Doppler.BillingUser/Controllers/BillingController.cs
@@ -20,7 +20,7 @@ namespace Doppler.BillingUser.Controllers
             _billingRepository = billingRepository;
         }
 
-        //[Authorize(Policies.OWN_RESOURCE_OR_SUPERUSER)]
+        [Authorize(Policies.OWN_RESOURCE_OR_SUPERUSER)]
         [HttpGet("/accounts/{accountName}/billing-information")]
         public async Task<IActionResult> GetBillingInformation(string accountName)
         {

--- a/Doppler.BillingUser/Doppler.BillingUser.csproj
+++ b/Doppler.BillingUser/Doppler.BillingUser.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Dapper" Version="2.0.90" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.7" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.14" />
     <PackageReference Include="Serilog.Exceptions" Version="6.1.0" />
@@ -17,6 +18,7 @@
     <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
     <PackageReference Include="Serilog.Sinks.Loggly" Version="5.4.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.4" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
   </ItemGroup>
 
 </Project>

--- a/Doppler.BillingUser/Infrastructure/BillingRepository.cs
+++ b/Doppler.BillingUser/Infrastructure/BillingRepository.cs
@@ -21,17 +21,17 @@ namespace Doppler.BillingUser.Infrastructure
 SELECT
     U.BillingFirstName AS Firstname,
     U.BillingLastName AS Lastname,
-    U.Address,
-    U.CityName AS City,
+    U.BillingAddress AS Address,
+    U.BillingCity AS City,
     isnull(S.Name, '') AS Province,
     isnull(CO.Code, '') AS Country,
-    U.ZipCode,
-    U.PhoneNumber AS Phone,
+    U.BillingZip AS ZipCode,
+    U.BillingPhone AS Phone,
     U.IdSecurityQuestion AS ChooseQuestion,
     U.IdSecurityQuestion AS AnswerQuestion
 FROM
     [User] U
-    LEFT JOIN [State] S ON U.IdState = S.IdState
+    LEFT JOIN [State] S ON U.IdBillingState = S.IdState
     LEFT JOIN [Country] CO ON S.IdCountry = CO.IdCountry
     LEFT JOIN [SecurityQuestion] SQ ON SQ.IdSecurityQuestion = U.IdSecurityQuestion
 WHERE

--- a/Doppler.BillingUser/Infrastructure/BillingRepository.cs
+++ b/Doppler.BillingUser/Infrastructure/BillingRepository.cs
@@ -1,0 +1,44 @@
+using Dapper;
+using Doppler.BillingUser.Model;
+using System.Data;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Doppler.BillingUser.Infrastructure
+{
+    public class BillingRepository : IBillingRepository
+    {
+        private readonly IDatabaseConnectionFactory _connectionFactory;
+        public BillingRepository(IDatabaseConnectionFactory connectionFactory)
+        {
+            _connectionFactory = connectionFactory;
+        }
+        public async Task<BillingInformation> GetBillingInformation(string email)
+        {
+            using (IDbConnection connection = await _connectionFactory.GetConnection())
+            {
+                var results = await connection.QueryAsync<BillingInformation>(@"
+SELECT
+    U.BillingFirstName AS Firstname,
+    U.BillingLastName AS Lastname,
+    U.Address,
+    U.CityName AS City,
+    isnull(S.Name, '') AS Province,
+    isnull(CO.Code, '') AS Country,
+    U.ZipCode,
+    U.PhoneNumber AS Phone,
+    U.IdSecurityQuestion AS ChooseQuestion,
+    U.IdSecurityQuestion AS AnswerQuestion
+FROM
+    [User] U
+    LEFT JOIN [State] S ON U.IdState = S.IdState
+    LEFT JOIN [Country] CO ON S.IdCountry = CO.IdCountry
+    LEFT JOIN [SecurityQuestion] SQ ON SQ.IdSecurityQuestion = U.IdSecurityQuestion
+WHERE
+    U.Email = @email",
+                    new { email });
+                return results.FirstOrDefault();
+            }
+        }
+    }
+}

--- a/Doppler.BillingUser/Infrastructure/BillingRepository.cs
+++ b/Doppler.BillingUser/Infrastructure/BillingRepository.cs
@@ -23,17 +23,14 @@ SELECT
     U.BillingLastName AS Lastname,
     U.BillingAddress AS Address,
     U.BillingCity AS City,
-    isnull(S.Name, '') AS Province,
+    isnull(S.StateCode, '') AS Province,
     isnull(CO.Code, '') AS Country,
     U.BillingZip AS ZipCode,
-    U.BillingPhone AS Phone,
-    U.IdSecurityQuestion AS ChooseQuestion,
-    U.IdSecurityQuestion AS AnswerQuestion
+    U.BillingPhone AS Phone
 FROM
     [User] U
     LEFT JOIN [State] S ON U.IdBillingState = S.IdState
     LEFT JOIN [Country] CO ON S.IdCountry = CO.IdCountry
-    LEFT JOIN [SecurityQuestion] SQ ON SQ.IdSecurityQuestion = U.IdSecurityQuestion
 WHERE
     U.Email = @email",
                     new { email });

--- a/Doppler.BillingUser/Infrastructure/DatabaseConnectionFactory.cs
+++ b/Doppler.BillingUser/Infrastructure/DatabaseConnectionFactory.cs
@@ -1,0 +1,28 @@
+using Microsoft.Extensions.Options;
+using System.Data;
+using System.Data.SqlClient;
+using System.Threading.Tasks;
+
+namespace Doppler.BillingUser.Infrastructure
+{
+    public class DatabaseConnectionFactory : IDatabaseConnectionFactory
+    {
+        private readonly string _connectionString;
+
+        public DatabaseConnectionFactory(IOptions<DopplerDatabaseSettings> dopplerDataBaseSettings)
+        {
+            _connectionString = dopplerDataBaseSettings.Value.GetSqlConnectionString();
+        }
+
+        /// <summary>
+        /// Open new connection and return it for use
+        /// </summary>
+        /// <returns></returns>
+        public async Task<IDbConnection> GetConnection()
+        {
+            var cn = new SqlConnection(_connectionString);
+            await cn.OpenAsync();
+            return cn;
+        }
+    }
+}

--- a/Doppler.BillingUser/Infrastructure/DopplerDatabaseSettings.cs
+++ b/Doppler.BillingUser/Infrastructure/DopplerDatabaseSettings.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Data.SqlClient;
+
+namespace Doppler.BillingUser.Infrastructure
+{
+    public class DopplerDatabaseSettings
+    {
+        public string ConnectionString { get; set; }
+
+        public string Password { get; set; }
+
+        public int CommandTimeOut { get; set; } = 1200;
+
+        public int MaxRetryAttempts { get; set; } = 10;
+
+        public string GetSqlConnectionString()
+        {
+            if (string.IsNullOrWhiteSpace(ConnectionString))
+            {
+                throw new ArgumentException("The string argument 'connectionString' cannot be empty.");
+            }
+
+            var builder = new SqlConnectionStringBuilder(ConnectionString);
+
+            if (!string.IsNullOrWhiteSpace(Password))
+            {
+                builder.Password = Password;
+            }
+
+            return builder.ConnectionString;
+        }
+    }
+}

--- a/Doppler.BillingUser/Infrastructure/IBillingRepository.cs
+++ b/Doppler.BillingUser/Infrastructure/IBillingRepository.cs
@@ -1,0 +1,10 @@
+using Doppler.BillingUser.Model;
+using System.Threading.Tasks;
+
+namespace Doppler.BillingUser.Infrastructure
+{
+    public interface IBillingRepository
+    {
+        Task<BillingInformation> GetBillingInformation(string accountName);
+    }
+}

--- a/Doppler.BillingUser/Infrastructure/IDatabaseConnectionFactory.cs
+++ b/Doppler.BillingUser/Infrastructure/IDatabaseConnectionFactory.cs
@@ -1,0 +1,10 @@
+using System.Data;
+using System.Threading.Tasks;
+
+namespace Doppler.BillingUser.Infrastructure
+{
+    public interface IDatabaseConnectionFactory
+    {
+        Task<IDbConnection> GetConnection();
+    }
+}

--- a/Doppler.BillingUser/Infrastructure/InfrastructureServiceCollectionExtensions.cs
+++ b/Doppler.BillingUser/Infrastructure/InfrastructureServiceCollectionExtensions.cs
@@ -1,0 +1,14 @@
+using Doppler.BillingUser.Infrastructure;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public static class InfrastructureServiceCollectionExtensions
+    {
+        public static IServiceCollection AddRepositories(this IServiceCollection services)
+        {
+            services.AddScoped<BillingRepository, BillingRepository>();
+            services.AddScoped<IDatabaseConnectionFactory, DatabaseConnectionFactory>();
+            return services;
+        }
+    }
+}

--- a/Doppler.BillingUser/Model/BillingInformation.cs
+++ b/Doppler.BillingUser/Model/BillingInformation.cs
@@ -1,0 +1,16 @@
+namespace Doppler.BillingUser.Model
+{
+    public class BillingInformation
+    {
+        public string Firstname { get; set; }
+        public string Lastname { get; set; }
+        public string Address { get; set; }
+        public string City { get; set; }
+        public string Province { get; set; }
+        public string Country { get; set; }
+        public string ZipCode { get; set; }
+        public string Phone { get; set; }
+        public int ChooseQuestion { get; set; }
+        public string AnswerQuestion { get; set; }
+    }
+}

--- a/Doppler.BillingUser/Model/BillingInformation.cs
+++ b/Doppler.BillingUser/Model/BillingInformation.cs
@@ -10,7 +10,5 @@ namespace Doppler.BillingUser.Model
         public string Country { get; set; }
         public string ZipCode { get; set; }
         public string Phone { get; set; }
-        public int ChooseQuestion { get; set; }
-        public string AnswerQuestion { get; set; }
     }
 }

--- a/Doppler.BillingUser/Startup.cs
+++ b/Doppler.BillingUser/Startup.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Doppler.BillingUser.Infrastructure;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
@@ -25,7 +26,9 @@ namespace Doppler.BillingUser
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            services.Configure<DopplerDatabaseSettings>(Configuration.GetSection(nameof(DopplerDatabaseSettings)));
             services.AddDopplerSecurity();
+            services.AddRepositories();
             services.AddControllers();
             services.AddSingleton<Weather.WeatherForecastService>();
             services.AddSingleton<Weather.DataService>();

--- a/Doppler.BillingUser/Startup.cs
+++ b/Doppler.BillingUser/Startup.cs
@@ -30,6 +30,7 @@ namespace Doppler.BillingUser
             services.AddDopplerSecurity();
             services.AddRepositories();
             services.AddControllers();
+            services.AddCors();
             services.AddSingleton<Weather.WeatherForecastService>();
             services.AddSingleton<Weather.DataService>();
             services.AddSwaggerGen(c =>
@@ -62,7 +63,6 @@ namespace Doppler.BillingUser
                     c.AddServer(new OpenApiServer() { Url = baseUrl });
                 };
             });
-            services.AddCors();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -80,18 +80,18 @@ namespace Doppler.BillingUser
 
             app.UseRouting();
 
+            app.UseCors(policy => policy
+                .SetIsOriginAllowed(isOriginAllowed: _ => true)
+                .AllowAnyHeader()
+                .AllowAnyMethod()
+                .AllowCredentials());
+
             app.UseAuthorization();
 
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapControllers();
             });
-
-            app.UseCors(policy => policy
-                .SetIsOriginAllowed(isOriginAllowed: _ => true)
-                .AllowAnyHeader()
-                .AllowAnyMethod()
-                .AllowCredentials());
         }
     }
 }

--- a/Doppler.BillingUser/appsettings.Development.json
+++ b/Doppler.BillingUser/appsettings.Development.json
@@ -10,5 +10,9 @@
   },
   "DopplerSecurity": {
     "PublicKeysFolder": "public-keys-dev"
+  },
+  "DopplerDataBaseSettings": {
+    "ConnectionString": "Data Source=192.168.6.33\\INT;Initial Catalog=Doppler2011;Persist Security Info=True;User ID=DopplerAppUser;MultipleActiveResultSets=True;Application Name=Doppler.Users.Api",
+    "Password": "123456"
   }
 }

--- a/Doppler.BillingUser/appsettings.json
+++ b/Doppler.BillingUser/appsettings.json
@@ -15,5 +15,9 @@
   "DopplerSecurity": {
     "PublicKeysFolder": "public-keys",
     "PublicKeysFilenameRegex": "\\.xml$"
+  },
+  "DopplerDataBaseSettings": {
+    "ConnectionString": "Server=REPLACE_FOR_SQL_SERVER;Database=REPLACE_FOR_DATABASE_NAME;User Id=REPLACE_FOR_DATABASE_USERNAME; MultipleActiveResultSets=True;",
+    "Password": "REPLACE_FOR_DATABASE_PASSWORD"
   }
 }


### PR DESCRIPTION
Here is added a new endpoint, in order to get the user billing information:
```
{
  firstname: string;
  lastname: string;
  address: string;
  city: string;
  province: string;
  country: string;
  zipCode: string;
  phone: string;
}
```

*We used a JSON for the security questions that it was save in cdn:
- ES: https://cdn.fromdoppler.com/static-data/questions-es.json
- EN: https://cdn.fromdoppler.com/static-data/questions-en.json