### PR TITLE
feat: [DAT-538] Add Get current payment method endpoint

### DIFF
--- a/Doppler.BillingUser.Test/GetCurrentPaymentMethodTest.cs
+++ b/Doppler.BillingUser.Test/GetCurrentPaymentMethodTest.cs
@@ -67,7 +67,7 @@ namespace Doppler.BillingUser.Test
         public async Task GET_current_payment_method_should_get_right_values_when_username_is_valid()
         {
             // Arrange
-            const string expectedContent = "{\"ccHolderFullName\":\"TEST\",\"ccNumber\":\"TEST\",\"ccVerification\":\"****\",\"ccExpMonth\":\"2\",\"ccExpYear\":\"2130\",\"ccType\":\"Visa\",\"paymentMethodName\":\"CC\",\"renewalMonth\":\"6\",\"cuit\":\"39404521\",\"razonSocial\":\"Company\",\"idConsumerType\":\"9\",\"ccIdentificationType\":\"DNI\",\"ccIdentificationNumber\":\"344444\"}";
+            const string expectedContent = "{\"ccHolderFullName\":\"TEST\",\"ccNumber\":\"TEST\",\"ccVerification\":\"****\",\"ccExpMonth\":\"2\",\"ccExpYear\":\"2130\",\"ccType\":\"Visa\",\"paymentMethodName\":\"CC\",\"renewalMonth\":\"6\",\"razonSocial\":\"Company\",\"idConsumerType\":\"9\",\"identificationType\":\"DNI\",\"identificationNumber\":\"344444\"}";
             var paymentMethod = new PaymentMethod
             {
                 PaymentMethodName = "CC",
@@ -75,11 +75,10 @@ namespace Doppler.BillingUser.Test
                 CCExpMonth = "2",
                 CCExpYear = "2130",
                 CCHolderFullName = "Test holder Name",
-                CCIdentificationNumber = "344444",
-                CCIdentificationType = "DNI",
+                IdentificationNumber = "344444",
+                IdentificationType = "DNI",
                 CCType = "Visa",
                 CCVerification = "213",
-                Cuit = "39404521",
                 IdConsumerType = "9",
                 RazonSocial = "Company",
                 RenewalMonth = "6"

--- a/Doppler.BillingUser.Test/GetCurrentPaymentMethodTest.cs
+++ b/Doppler.BillingUser.Test/GetCurrentPaymentMethodTest.cs
@@ -1,0 +1,124 @@
+using System.Data.Common;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Dapper;
+using Doppler.BillingUser.Encryption;
+using Doppler.BillingUser.Model;
+using Doppler.BillingUser.Test.Utils;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Moq.Dapper;
+using Xunit;
+
+namespace Doppler.BillingUser.Test
+{
+    public class GetCurrentPaymentMethodTest : IClassFixture<WebApplicationFactory<Startup>>
+    {
+        private const string TokenAccount123Test1AtTestDotComExpire20330518 = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1laWQiOjEyMywidW5pcXVlX25hbWUiOiJ0ZXN0MUB0ZXN0LmNvbSIsInJvbGUiOiJVU0VSIiwiZXhwIjoyMDAwMDAwMDAwfQ.E3RHjKx9p0a-64RN2YPtlEMysGM45QBO9eATLBhtP4tUQNZnkraUr56hAWA-FuGmhiuMptnKNk_dU3VnbyL6SbHrMWUbquxWjyoqsd7stFs1K_nW6XIzsTjh8Bg6hB5hmsSV-M5_hPS24JwJaCdMQeWrh6cIEp2Sjft7I1V4HQrgzrkMh15sDFAw3i1_ZZasQsDYKyYbO9Jp7lx42ognPrz_KuvPzLjEXvBBNTFsVXUE-ur5adLNMvt-uXzcJ1rcwhjHWItUf5YvgRQbbBnd9f-LsJIhfkDgCJcvZmGDZrtlCKaU1UjHv5c3faZED-cjL59MbibofhPjv87MK8hhdg";
+        private const string TokenAccount123Test1AtTestDotComExpire20010908 = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1laWQiOjEyMywidW5pcXVlX25hbWUiOiJ0ZXN0MUB0ZXN0LmNvbSIsInJvbGUiOiJVU0VSIiwiZXhwIjoxMDAwMDAwMDAwfQ.JBmiZBgKVSUtB4_NhD1kiUhBTnH2ufGSzcoCwC3-Gtx0QDvkFjy2KbxIU9asscenSdzziTOZN6IfFx6KgZ3_a3YB7vdCgfSINQwrAK0_6Owa-BQuNAIsKk-pNoIhJ-OcckV-zrp5wWai3Ak5Qzg3aZ1NKZQKZt5ICZmsFZcWu_4pzS-xsGPcj5gSr3Iybt61iBnetrkrEbjtVZg-3xzKr0nmMMqe-qqeknozIFy2YWAObmTkrN4sZ3AB_jzqyFPXN-nMw3a0NxIdJyetbESAOcNnPLymBKZEZmX2psKuXwJxxekvgK9egkfv2EjKYF9atpH5XwC0Pd4EWvraLAL2eg";
+        private readonly WebApplicationFactory<Startup> _factory;
+
+        public GetCurrentPaymentMethodTest(WebApplicationFactory<Startup> factory)
+        {
+            _factory = factory;
+        }
+
+        [Theory]
+        [InlineData(TokenAccount123Test1AtTestDotComExpire20010908)]
+        [InlineData("")]
+        [InlineData("invalid")]
+        public async Task GET_current_payment_method_should_be_return_unauthorized_When_token_is_invalid(string token)
+        {
+            // Arrange
+            var client = _factory.CreateClient(new WebApplicationFactoryClientOptions
+            {
+                AllowAutoRedirect = false
+            });
+            var request = new HttpRequestMessage(HttpMethod.Get, "accounts/test1@test.com/payment-methods/current")
+            {
+                Headers = { { "Authorization", $"Bearer {token}" } }
+            };
+
+            // Act
+            var response = await client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task GET_current_payment_method_should_return_unauthorized_when_authorization_is_empty()
+        {
+            // Arrange
+            var client = _factory.CreateClient(new WebApplicationFactoryClientOptions());
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "accounts/test1@test.com/payment-methods/current");
+
+            // Act
+            var response = await client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+        [Fact]
+        public async Task GET_current_payment_method_should_get_right_values_when_username_is_valid()
+        {
+            // Arrange
+            const string expectedContent = "{\"ccHolderFullName\":\"TEST\",\"ccNumber\":\"TEST\",\"ccVerification\":\"****\",\"ccExpMonth\":\"2\",\"ccExpYear\":\"2130\",\"ccType\":\"Visa\",\"paymentMethodName\":\"CC\",\"renewalMonth\":\"6\",\"cuit\":\"39404521\",\"razonSocial\":\"Company\",\"idConsumerType\":\"9\",\"ccIdentificationType\":\"DNI\",\"ccIdentificationNumber\":\"344444\"}";
+            var paymentMethod = new PaymentMethod
+            {
+                PaymentMethodName = "CC",
+                CCNumber = "41111111",
+                CCExpMonth = "2",
+                CCExpYear = "2130",
+                CCHolderFullName = "Test holder Name",
+                CCIdentificationNumber = "344444",
+                CCIdentificationType = "DNI",
+                CCType = "Visa",
+                CCVerification = "213",
+                Cuit = "39404521",
+                IdConsumerType = "9",
+                RazonSocial = "Company",
+                RenewalMonth = "6"
+            };
+
+            var mockConnection = new Mock<DbConnection>();
+            mockConnection.SetupDapperAsync(c => c.QueryFirstOrDefaultAsync<PaymentMethod>(null, null, null, null, null))
+                .ReturnsAsync(paymentMethod);
+
+            var encryptedMock = new Mock<IEncryptionService>();
+            encryptedMock.Setup(x => x.DecryptAES256(It.IsAny<string>())).Returns("TEST");
+
+            var client = _factory.WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    services.SetupConnectionFactory(mockConnection.Object);
+                    services.AddSingleton(encryptedMock.Object);
+                });
+
+            }).CreateClient(new WebApplicationFactoryClientOptions());
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "accounts/test1@test.com/payment-methods/current")
+            {
+                Headers =
+                {
+                    {
+                        "Authorization", $"Bearer {TokenAccount123Test1AtTestDotComExpire20330518}"
+                    }
+                }
+            };
+
+            // Act
+            var response = await client.SendAsync(request);
+            var responseContent = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Equal(expectedContent, responseContent);
+        }
+
+    }
+}

--- a/Doppler.BillingUser/Controllers/BillingController.cs
+++ b/Doppler.BillingUser/Controllers/BillingController.cs
@@ -58,9 +58,18 @@ namespace Doppler.BillingUser.Controllers
 
         [Authorize(Policies.OWN_RESOURCE_OR_SUPERUSER)]
         [HttpGet("/accounts/{accountname}/payment-methods/current")]
-        public string GetCurrentPaymentMethod(string accountname)
+        public async Task<IActionResult> GetCurrentPaymentMethod(string accountname)
         {
-            return $"Hello! \"you\" that have access to GetCurrentPaymentMethod with accountname '{accountname}'";
+            _logger.LogDebug("Get current payment method.");
+
+            var currentPaymentMethod = await _billingRepository.GetCurrentPaymentMethod(accountname);
+
+            if (currentPaymentMethod == null)
+            {
+                return new NotFoundResult();
+            }
+
+            return new OkObjectResult(currentPaymentMethod);
         }
 
         [Authorize(Policies.OWN_RESOURCE_OR_SUPERUSER)]

--- a/Doppler.BillingUser/Encryption/EncryptionService.cs
+++ b/Doppler.BillingUser/Encryption/EncryptionService.cs
@@ -1,0 +1,98 @@
+using System;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.Extensions.Options;
+
+namespace Doppler.BillingUser.Encryption
+{
+    public class EncryptionService : IEncryptionService, IDisposable
+    {
+        private readonly IOptions<EncryptionSettings> _options;
+        private bool _initialized;
+        private RijndaelManaged _symmetricKey;
+        private Lazy<ICryptoTransform> _encryptor;
+        private Lazy<ICryptoTransform> _decryptor;
+
+        public EncryptionService(IOptions<EncryptionSettings> options)
+        {
+            _options = options;
+        }
+
+        public string DecryptAES256(string input)
+        {
+            if (string.IsNullOrEmpty(input))
+            {
+                return string.Empty;
+            }
+
+            EnsureInitialization();
+
+            var cipherTextBytes = Convert.FromBase64String(input);
+
+            using var memoryStream = new MemoryStream(cipherTextBytes);
+            using var cryptoStream = new CryptoStream(memoryStream, _decryptor.Value, CryptoStreamMode.Read);
+            var plainTextBytes = new byte[cipherTextBytes.Length];
+            var decryptedByteCount = cryptoStream.Read(plainTextBytes, 0, plainTextBytes.Length);
+            return Encoding.UTF8.GetString(plainTextBytes, 0, decryptedByteCount);
+        }
+
+        public string EncryptAES256(string input)
+        {
+            if (string.IsNullOrEmpty(input))
+            {
+                return string.Empty;
+            }
+
+            EnsureInitialization();
+
+            var plainTextBytes = Encoding.UTF8.GetBytes(input);
+
+            using var memoryStream = new MemoryStream();
+            using var cryptoStream = new CryptoStream(memoryStream, _encryptor.Value, CryptoStreamMode.Write);
+            cryptoStream.Write(plainTextBytes, 0, plainTextBytes.Length);
+            cryptoStream.FlushFinalBlock();
+            return Convert.ToBase64String(memoryStream.ToArray());
+        }
+
+        private void EnsureInitialization()
+        {
+            if (_initialized)
+            {
+                return;
+            }
+
+            var initVectorBytes = Encoding.ASCII.GetBytes(_options.Value.InitVectorAsAsciiString);
+            var password = new PasswordDeriveBytes(
+                _options.Value.Password,
+                Encoding.ASCII.GetBytes(_options.Value.SaltValueAsAsciiString),
+                "SHA1",
+                5);
+
+            var keyBytes = password.GetBytes(32); // KeySize = 256 bits = 32 bytes
+
+            _symmetricKey = new RijndaelManaged() { Mode = CipherMode.CBC };
+            _encryptor = new Lazy<ICryptoTransform>(() => _symmetricKey.CreateEncryptor(keyBytes, initVectorBytes));
+            _decryptor = new Lazy<ICryptoTransform>(() => _symmetricKey.CreateDecryptor(keyBytes, initVectorBytes));
+            _initialized = true;
+        }
+
+        public void Dispose()
+        {
+            if (!_initialized)
+            {
+                return;
+            }
+
+            if (_decryptor.IsValueCreated)
+            {
+                _decryptor.Value.Dispose();
+            }
+
+            if (_encryptor.IsValueCreated)
+            {
+                _encryptor.Value.Dispose();
+            }
+        }
+    }
+}

--- a/Doppler.BillingUser/Encryption/EncryptionSettings.cs
+++ b/Doppler.BillingUser/Encryption/EncryptionSettings.cs
@@ -1,0 +1,9 @@
+namespace Doppler.BillingUser.Encryption
+{
+    public class EncryptionSettings
+    {
+        public string InitVectorAsAsciiString { get; set; }
+        public string SaltValueAsAsciiString { get; set; }
+        public string Password { get; set; }
+    }
+}

--- a/Doppler.BillingUser/Encryption/IEncryptionService.cs
+++ b/Doppler.BillingUser/Encryption/IEncryptionService.cs
@@ -1,0 +1,9 @@
+namespace Doppler.BillingUser.Encryption
+{
+    public interface IEncryptionService
+    {
+        public string DecryptAES256(string input);
+        void Dispose();
+        public string EncryptAES256(string input);
+    }
+}

--- a/Doppler.BillingUser/Infrastructure/BillingRepository.cs
+++ b/Doppler.BillingUser/Infrastructure/BillingRepository.cs
@@ -85,11 +85,10 @@ SELECT
     C.[Description] AS CCType,
     P.PaymentMethodName AS PaymentMethodName,
     D.MonthPlan AS RenewalMonth,
-    B.CUIT,
     B.RazonSocial,
     B.IdConsumerType,
-    B.CCIdentificationType,
-    B.CCIdentificationNumber
+    B.CCIdentificationType AS IdentificationType,
+    ISNULL(B.CUIT, B.CCIdentificationNumber) AS IdentificationNumber
 FROM
     [BillingCredits] B
 LEFT JOIN

--- a/Doppler.BillingUser/Infrastructure/BillingRepository.cs
+++ b/Doppler.BillingUser/Infrastructure/BillingRepository.cs
@@ -3,15 +3,20 @@ using Doppler.BillingUser.Model;
 using System.Data;
 using System.Linq;
 using System.Threading.Tasks;
+using Doppler.BillingUser.Encryption;
+using Doppler.BillingUser.Utils;
 
 namespace Doppler.BillingUser.Infrastructure
 {
     public class BillingRepository : IBillingRepository
     {
         private readonly IDatabaseConnectionFactory _connectionFactory;
-        public BillingRepository(IDatabaseConnectionFactory connectionFactory)
+        private readonly IEncryptionService _encryptionService;
+
+        public BillingRepository(IDatabaseConnectionFactory connectionFactory, IEncryptionService encryptionService)
         {
             _connectionFactory = connectionFactory;
+            _encryptionService = encryptionService;
         }
         public async Task<BillingInformation> GetBillingInformation(string email)
         {
@@ -64,6 +69,50 @@ WHERE
                     @zipCode = billingInformation.ZipCode,
                     @email = accountName
                 });
+        }
+
+        public async Task<PaymentMethod> GetCurrentPaymentMethod(string username)
+        {
+            using var connection = await _connectionFactory.GetConnection();
+
+            var result = await connection.QueryFirstOrDefaultAsync<PaymentMethod>(@"
+SELECT
+    B.CCHolderFullName,
+    B.CCNumber,
+    B.CCExpMonth,
+    B.CCExpYear,
+    B.CCVerification,
+    C.[Description] AS CCType,
+    P.PaymentMethodName AS PaymentMethodName,
+    D.MonthPlan AS RenewalMonth,
+    B.CUIT,
+    B.RazonSocial,
+    B.IdConsumerType,
+    B.CCIdentificationType,
+    B.CCIdentificationNumber
+FROM
+    [BillingCredits] B
+LEFT JOIN
+    [PaymentMethods] P ON P.IdPaymentMethod = B.IdPaymentMethod
+LEFT JOIN
+    [CreditCardTypes] C ON C.IdCCType = B.IdCCType
+LEFT JOIN
+    [DiscountXPlan] D ON D.IdDiscountPlan = B.IdDiscountPlan
+WHERE
+    B.IdUser = (SELECT IdUser FROM [User] WHERE Email = @email) ORDER BY [Date] DESC;",
+                new
+                {
+                    @email = username
+                });
+
+            if (result is not { PaymentMethodName: "CC" or "MP" })
+                return result;
+
+            result.CCHolderFullName = _encryptionService.DecryptAES256(result.CCHolderFullName);
+            result.CCNumber = CreditCardHelper.ObfuscateNumber(_encryptionService.DecryptAES256(result.CCNumber));
+            result.CCVerification = CreditCardHelper.ObfuscateVerificationCode(_encryptionService.DecryptAES256(result.CCVerification));
+
+            return result;
         }
     }
 }

--- a/Doppler.BillingUser/Infrastructure/IBillingRepository.cs
+++ b/Doppler.BillingUser/Infrastructure/IBillingRepository.cs
@@ -8,5 +8,7 @@ namespace Doppler.BillingUser.Infrastructure
         Task<BillingInformation> GetBillingInformation(string accountName);
 
         Task UpdateBillingInformation(string accountName, BillingInformation billingInformation);
+
+        Task<PaymentMethod> GetCurrentPaymentMethod(string username);
     }
 }

--- a/Doppler.BillingUser/Model/PaymentMethod.cs
+++ b/Doppler.BillingUser/Model/PaymentMethod.cs
@@ -10,10 +10,9 @@ namespace Doppler.BillingUser.Model
         public string CCType { get; set; }
         public string PaymentMethodName { get; set; }
         public string RenewalMonth { get; set; }
-        public string Cuit { get; set; }
         public string RazonSocial { get; set; }
         public string IdConsumerType { get; set; }
-        public string CCIdentificationType { get; set; }
-        public string CCIdentificationNumber { get; set; }
+        public string IdentificationType { get; set; }
+        public string IdentificationNumber { get; set; }
     }
 }

--- a/Doppler.BillingUser/Model/PaymentMethod.cs
+++ b/Doppler.BillingUser/Model/PaymentMethod.cs
@@ -1,0 +1,19 @@
+namespace Doppler.BillingUser.Model
+{
+    public class PaymentMethod
+    {
+        public string CCHolderFullName { get; set; }
+        public string CCNumber { get; set; }
+        public string CCVerification { get; set; }
+        public string CCExpMonth { get; set; }
+        public string CCExpYear { get; set; }
+        public string CCType { get; set; }
+        public string PaymentMethodName { get; set; }
+        public string RenewalMonth { get; set; }
+        public string Cuit { get; set; }
+        public string RazonSocial { get; set; }
+        public string IdConsumerType { get; set; }
+        public string CCIdentificationType { get; set; }
+        public string CCIdentificationNumber { get; set; }
+    }
+}

--- a/Doppler.BillingUser/Startup.cs
+++ b/Doppler.BillingUser/Startup.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Doppler.BillingUser.Encryption;
 using Doppler.BillingUser.Infrastructure;
 using Doppler.BillingUser.Model;
 using Doppler.BillingUser.Validators;
@@ -67,6 +68,8 @@ namespace Doppler.BillingUser
                 };
             });
 
+            services.Configure<EncryptionSettings>(Configuration.GetSection(nameof(EncryptionSettings)));
+            services.AddScoped<IEncryptionService, EncryptionService>();
             services.AddScoped<IValidator<BillingInformation>, BillingInformationValidator>();
         }
 

--- a/Doppler.BillingUser/Utils/CreditCardHelper.cs
+++ b/Doppler.BillingUser/Utils/CreditCardHelper.cs
@@ -1,0 +1,17 @@
+namespace Doppler.BillingUser.Utils
+{
+    public static class CreditCardHelper
+    {
+        public static string ObfuscateNumber(string cardNumber)
+        {
+            const int clearChars = 4;
+            var start = cardNumber.Length - clearChars;
+            return $"{new string('*', start)}{cardNumber.Substring(start, clearChars)}";
+        }
+
+        public static string ObfuscateVerificationCode(string code)
+        {
+            return $"{new string('*', code.Length)}";
+        }
+    }
+}


### PR DESCRIPTION
# Background
We need support for Transfers, Credit card’s and Mercadopago to get information about the Payment method
endpoint  `Get /accounts/{username}/payment-methods/current`
return
```
{
    "ccHolderFullName": "Lorena Motta",
    "ccNumber": "************4916",
    "ccVerification": "***",
    "ccExpMonth": "6",
    "ccExpYear": "2025",
    "ccType": "Visa",
    "paymentMethodName": "MP",
    "renewalMonth": "1",
    "razonSocial": null,
    "idConsumerType": "1",
    "identificationType": "DNI",
    "identificationNumber": "29435331"
}
```