### PR TITLE
feat: [DAT-633] Add ConsumerType helper

### DIFF
--- a/Doppler.BillingUser.Test/GetCurrentPaymentMethodTest.cs
+++ b/Doppler.BillingUser.Test/GetCurrentPaymentMethodTest.cs
@@ -67,7 +67,7 @@ namespace Doppler.BillingUser.Test
         public async Task GET_current_payment_method_should_get_right_values_when_username_is_valid()
         {
             // Arrange
-            const string expectedContent = "{\"ccHolderFullName\":\"TEST\",\"ccNumber\":\"TEST\",\"ccVerification\":\"****\",\"ccExpMonth\":\"2\",\"ccExpYear\":\"2130\",\"ccType\":\"Visa\",\"paymentMethodName\":\"CC\",\"renewalMonth\":\"6\",\"razonSocial\":\"Company\",\"idConsumerType\":\"9\",\"identificationType\":\"DNI\",\"identificationNumber\":\"344444\"}";
+            const string expectedContent = "{\"ccHolderFullName\":\"TEST\",\"ccNumber\":\"TEST\",\"ccVerification\":\"****\",\"ccExpMonth\":\"2\",\"ccExpYear\":\"2130\",\"ccType\":\"Visa\",\"paymentMethodName\":\"CC\",\"renewalMonth\":\"6\",\"razonSocial\":\"Company\",\"idConsumerType\":\"NC\",\"identificationType\":\"DNI\",\"identificationNumber\":\"344444\"}";
             var paymentMethod = new PaymentMethod
             {
                 PaymentMethodName = "CC",

--- a/Doppler.BillingUser/Infrastructure/BillingRepository.cs
+++ b/Doppler.BillingUser/Infrastructure/BillingRepository.cs
@@ -104,6 +104,8 @@ WHERE
                     @email = username
                 });
 
+            result.IdConsumerType = ConsumerTypeHelper.GetConsumerType(result.IdConsumerType);
+
             if (result is not { PaymentMethodName: "CC" or "MP" })
                 return result;
 

--- a/Doppler.BillingUser/Utils/ConsumerTypeEnum.cs
+++ b/Doppler.BillingUser/Utils/ConsumerTypeEnum.cs
@@ -1,0 +1,14 @@
+namespace Doppler.BillingUser.Utils
+{
+    public enum ConsumerTypeEnum
+    {
+        CF = 1,
+        RI = 2,
+        RFC = 4,
+        RNI = 5,
+        MT = 6,
+        EX = 7,
+        NG = 8,
+        NC = 9
+    }
+}

--- a/Doppler.BillingUser/Utils/ConsumerTypeHelper.cs
+++ b/Doppler.BillingUser/Utils/ConsumerTypeHelper.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Doppler.BillingUser.Utils
+{
+    public static class ConsumerTypeHelper
+    {
+        public static string GetConsumerType(string idConsumerType)
+        {
+            var isConsumerTypeValid = Enum.TryParse<ConsumerTypeEnum>(idConsumerType, out var consumer);
+
+            return !isConsumerTypeValid ? null : consumer.ToString();
+        }
+    }
+}


### PR DESCRIPTION
# Background 
We need to send to Frontend the string of consumer type field, because the WebApp app uses the consumer type JSON files to map this value

https://cdn.fromdoppler.com/static-data/consumer-types-en-v1.json
https://cdn.fromdoppler.com/static-data/consumer-types-es-v1.json
