### PR TITLE
feat: [DAT-673] Add ResponsableIVA property for Colombia

### DIFF
--- a/Doppler.BillingUser.Test/GetCurrentPaymentMethodTest.cs
+++ b/Doppler.BillingUser.Test/GetCurrentPaymentMethodTest.cs
@@ -67,7 +67,7 @@ namespace Doppler.BillingUser.Test
         public async Task GET_current_payment_method_should_get_right_values_when_username_is_valid()
         {
             // Arrange
-            const string expectedContent = "{\"ccHolderFullName\":\"TEST\",\"ccNumber\":\"TEST\",\"ccVerification\":\"****\",\"ccExpMonth\":\"2\",\"ccExpYear\":\"2130\",\"ccType\":\"Visa\",\"paymentMethodName\":\"CC\",\"renewalMonth\":\"6\",\"razonSocial\":\"Company\",\"idConsumerType\":\"NC\",\"identificationType\":\"DNI\",\"identificationNumber\":\"344444\",\"idSelectedPlan\":1}";
+            const string expectedContent = "{\"ccHolderFullName\":\"TEST\",\"ccNumber\":\"TEST\",\"ccVerification\":\"****\",\"ccExpMonth\":\"2\",\"ccExpYear\":\"2130\",\"ccType\":\"Visa\",\"paymentMethodName\":\"CC\",\"renewalMonth\":\"6\",\"razonSocial\":\"Company\",\"idConsumerType\":\"NC\",\"identificationType\":\"DNI\",\"identificationNumber\":\"344444\",\"idSelectedPlan\":1,\"responsableIVA\":true}";
             var paymentMethod = new PaymentMethod
             {
                 PaymentMethodName = "CC",
@@ -82,7 +82,8 @@ namespace Doppler.BillingUser.Test
                 IdConsumerType = "9",
                 RazonSocial = "Company",
                 RenewalMonth = "6",
-                IdSelectedPlan = 1
+                IdSelectedPlan = 1,
+                ResponsableIVA = true
             };
 
             var mockConnection = new Mock<DbConnection>();

--- a/Doppler.BillingUser/Infrastructure/BillingRepository.cs
+++ b/Doppler.BillingUser/Infrastructure/BillingRepository.cs
@@ -100,7 +100,8 @@ SELECT
     P.PaymentMethodName AS PaymentMethodName,
     U.RazonSocial,
     U.IdConsumerType,
-    U.CUIT as IdentificationNumber
+    U.CUIT as IdentificationNumber,
+    U.ResponsableIVA
 FROM
     [User] U
 LEFT JOIN
@@ -192,7 +193,8 @@ SET
     RazonSocial = @razonSocial,
     IdConsumerType = (SELECT IdConsumerType FROM [ConsumerTypes] WHERE Name = @idConsumerType),
     IdResponsabileBilling = @idResponsabileBilling,
-    CUIT = @cuit
+    CUIT = @cuit,
+    ResponsableIVA = @responsableIVA
 WHERE
     IdUser = @IdUser;",
                 new
@@ -202,7 +204,8 @@ WHERE
                     @razonSocial = paymentMethod.RazonSocial,
                     @idConsumerType = paymentMethod.IdConsumerType,
                     @idResponsabileBilling = (int)ResponsabileBillingEnum.GBBISIDE,
-                    @cuit = paymentMethod.IdentificationNumber
+                    @cuit = paymentMethod.IdentificationNumber,
+                    @responsableIVA = paymentMethod.ResponsableIVA
                 });
         }
 

--- a/Doppler.BillingUser/Model/PaymentMethod.cs
+++ b/Doppler.BillingUser/Model/PaymentMethod.cs
@@ -15,5 +15,6 @@ namespace Doppler.BillingUser.Model
         public string IdentificationType { get; set; }
         public string IdentificationNumber { get; set; }
         public int IdSelectedPlan { get; set; }
+        public bool ResponsableIVA { get; set; }
     }
 }


### PR DESCRIPTION
# Background
We save ResponsableIVA in user table for Colombia country and the rest of the country
Example:
`{
  "paymentMethodName": "TRANSF",
  "ccType": "unknown",
  "idSelectedPlan": "13",
  "razonSocial": "",
  "idConsumerType": "CF",
  "identificationNumber": "12345678",
  "responsableIVA": false
}`