### PR TITLE
feat: [DAT-625] Add PUT email recipients endpoint

### DIFF
--- a/Doppler.BillingUser.Test/PutInvoiceRecipientsTest.cs
+++ b/Doppler.BillingUser.Test/PutInvoiceRecipientsTest.cs
@@ -1,0 +1,277 @@
+using System.Data.Common;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Dapper;
+using Doppler.BillingUser.Encryption;
+using Doppler.BillingUser.Enums;
+using Doppler.BillingUser.Model;
+using Doppler.BillingUser.Test.Utils;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Moq.Dapper;
+using Moq.Protected;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Doppler.BillingUser.Test
+{
+    public class PutInvoiceRecipientsTest : IClassFixture<WebApplicationFactory<Startup>>
+    {
+        private readonly WebApplicationFactory<Startup> _factory;
+        private const string TOKEN_ACCOUNT_123_TEST1_AT_TEST_DOT_COM_EXPIRE_20330518 = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1laWQiOjEyMywidW5pcXVlX25hbWUiOiJ0ZXN0MUB0ZXN0LmNvbSIsInJvbGUiOiJVU0VSIiwiZXhwIjoyMDAwMDAwMDAwfQ.E3RHjKx9p0a-64RN2YPtlEMysGM45QBO9eATLBhtP4tUQNZnkraUr56hAWA-FuGmhiuMptnKNk_dU3VnbyL6SbHrMWUbquxWjyoqsd7stFs1K_nW6XIzsTjh8Bg6hB5hmsSV-M5_hPS24JwJaCdMQeWrh6cIEp2Sjft7I1V4HQrgzrkMh15sDFAw3i1_ZZasQsDYKyYbO9Jp7lx42ognPrz_KuvPzLjEXvBBNTFsVXUE-ur5adLNMvt-uXzcJ1rcwhjHWItUf5YvgRQbbBnd9f-LsJIhfkDgCJcvZmGDZrtlCKaU1UjHv5c3faZED-cjL59MbibofhPjv87MK8hhdg";
+
+        public PutInvoiceRecipientsTest(WebApplicationFactory<Startup> factory)
+        {
+            _factory = factory;
+        }
+
+        [Fact]
+        public async Task PUT_Invoice_email_recipients_should_save_emails_recipients_correctly()
+        {
+            // Arrange
+            var user = new User
+            {
+                BillingEmails = "test@mail.com, test2@mail.com"
+            };
+
+            var mockConnection = new Mock<DbConnection>();
+            mockConnection.SetupDapperAsync(c => c.QueryFirstOrDefaultAsync<User>(null, null, null, null, null))
+                .ReturnsAsync(user);
+
+            var client = _factory.WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    services.SetupConnectionFactory(mockConnection.Object);
+                    services.AddSingleton(Mock.Of<IEncryptionService>());
+                });
+
+            }).CreateClient(new WebApplicationFactoryClientOptions());
+            var billingEmailRecipients = new EmailRecipients
+            {
+                Recipients = new[]
+                {
+                    "test@mail.com",
+                    "test2@mail.com"
+                }
+            };
+            var requestContent = new StringContent(JsonConvert.SerializeObject(billingEmailRecipients), Encoding.UTF8, "application/json");
+            var request = new HttpRequestMessage(HttpMethod.Put, "accounts/test1@test.com/billing-information/invoice-recipients")
+            {
+                Headers = { { "Authorization", $"Bearer {TOKEN_ACCOUNT_123_TEST1_AT_TEST_DOT_COM_EXPIRE_20330518}" } },
+                Content = requestContent
+            };
+
+            // Act
+            var response = await client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task PUT_Invoice_email_recipients_should_send_to_sap_with_email_recipients_when_user_has_billings_system_is_QBL()
+        {
+            // Arrange
+            var user = new User
+            {
+                BillingEmails = "test@mail.com, test2@mail.com",
+                SapProperties = "{\"ContractCurrency\" : false,\"GovernmentAccount\" : false,\"Premium\" : false,\"Plus\" : false,\"ComercialPartner\" : false,\"MarketingPartner\" : false,\"OnBoarding\" : false,\"Layout\" : false,\"Datahub\" : false,\"PushNotification\" : false,\"ExclusiveIp\" : false,\"Advisory\" : false,\"Reports\" : false,\"SMS\" : false}",
+                IdResponsabileBilling = (int)ResponsabileBillingEnum.QBL
+            };
+
+            var httpClientFactoryMock = new Mock<IHttpClientFactory>();
+            var httpMessageHandlerMock = new Mock<HttpMessageHandler>();
+
+            httpMessageHandlerMock.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent("")
+                });
+            var httpClient = new HttpClient(httpMessageHandlerMock.Object);
+            httpClientFactoryMock.Setup(_ => _.CreateClient(It.IsAny<string>()))
+                .Returns(httpClient);
+
+            var mockConnection = new Mock<DbConnection>();
+            mockConnection.SetupDapperAsync(c => c.QueryFirstOrDefaultAsync<User>(null, null, null, null, null))
+                .ReturnsAsync(user);
+
+            var client = _factory.WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    services.SetupConnectionFactory(mockConnection.Object);
+                    services.AddSingleton(Mock.Of<IEncryptionService>());
+                    services.AddSingleton(httpClientFactoryMock.Object);
+                });
+
+            }).CreateClient(new WebApplicationFactoryClientOptions());
+            var billingEmailRecipients = new EmailRecipients
+            {
+                Recipients = new[]
+                {
+                    "test@mail.com",
+                    "test2@mail.com"
+                }
+            };
+            var requestContent = new StringContent(JsonConvert.SerializeObject(billingEmailRecipients), Encoding.UTF8, "application/json");
+            var request = new HttpRequestMessage(HttpMethod.Put, "accounts/test1@test.com/billing-information/invoice-recipients")
+            {
+                Headers = { { "Authorization", $"Bearer {TOKEN_ACCOUNT_123_TEST1_AT_TEST_DOT_COM_EXPIRE_20330518}" } },
+                Content = requestContent
+            };
+
+            // Act
+            var response = await client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            httpMessageHandlerMock.Protected().Verify<Task<HttpResponseMessage>>("SendAsync", Times.Exactly(1),
+                ItExpr.Is<HttpRequestMessage>(
+                    req => req.Method == HttpMethod.Post
+                            && req.Content.ReadAsStringAsync().Result.Contains("\"BillingEmails\":[\"test@mail.com\",\"test2@mail.com\"]")
+                            && req.Content.ReadAsStringAsync().Result.Contains("\"BillingSystemId\":2")),
+                ItExpr.IsAny<CancellationToken>());
+        }
+
+        [Fact]
+        public async Task PUT_Invoice_email_recipients_should_send_to_sap_with_email_recipients_when_user_has_billings_system_is_GBBISIDE()
+        {
+            // Arrange
+            var user = new User
+            {
+                BillingEmails = "test@mail.com, test2@mail.com",
+                SapProperties = "{\"ContractCurrency\" : false,\"GovernmentAccount\" : false,\"Premium\" : false,\"Plus\" : false,\"ComercialPartner\" : false,\"MarketingPartner\" : false,\"OnBoarding\" : false,\"Layout\" : false,\"Datahub\" : false,\"PushNotification\" : false,\"ExclusiveIp\" : false,\"Advisory\" : false,\"Reports\" : false,\"SMS\" : false}",
+                IdResponsabileBilling = (int)ResponsabileBillingEnum.GBBISIDE
+            };
+
+            var httpClientFactoryMock = new Mock<IHttpClientFactory>();
+            var httpMessageHandlerMock = new Mock<HttpMessageHandler>();
+
+            httpMessageHandlerMock.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent("")
+                });
+            var httpClient = new HttpClient(httpMessageHandlerMock.Object);
+            httpClientFactoryMock.Setup(_ => _.CreateClient(It.IsAny<string>()))
+                .Returns(httpClient);
+
+            var mockConnection = new Mock<DbConnection>();
+            mockConnection.SetupDapperAsync(c => c.QueryFirstOrDefaultAsync<User>(null, null, null, null, null))
+                .ReturnsAsync(user);
+
+            var client = _factory.WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    services.SetupConnectionFactory(mockConnection.Object);
+                    services.AddSingleton(Mock.Of<IEncryptionService>());
+                    services.AddSingleton(httpClientFactoryMock.Object);
+                });
+
+            }).CreateClient(new WebApplicationFactoryClientOptions());
+            var billingEmailRecipients = new EmailRecipients
+            {
+                Recipients = new[]
+                {
+                    "test@mail.com",
+                    "test2@mail.com"
+                }
+            };
+            var requestContent = new StringContent(JsonConvert.SerializeObject(billingEmailRecipients), Encoding.UTF8, "application/json");
+            var request = new HttpRequestMessage(HttpMethod.Put, "accounts/test1@test.com/billing-information/invoice-recipients")
+            {
+                Headers = { { "Authorization", $"Bearer {TOKEN_ACCOUNT_123_TEST1_AT_TEST_DOT_COM_EXPIRE_20330518}" } },
+                Content = requestContent
+            };
+
+            // Act
+            var response = await client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            httpMessageHandlerMock.Protected().Verify<Task<HttpResponseMessage>>("SendAsync", Times.Exactly(1),
+                ItExpr.Is<HttpRequestMessage>(
+                    req => req.Method == HttpMethod.Post
+                            && req.Content.ReadAsStringAsync().Result.Contains("\"BillingEmails\":[\"test@mail.com\",\"test2@mail.com\"]")
+                            && req.Content.ReadAsStringAsync().Result.Contains("\"BillingSystemId\":9")),
+                ItExpr.IsAny<CancellationToken>());
+        }
+
+        [Fact]
+        public async Task PUT_Invoice_email_recipients_should_no_send_to_sap_with_email_recipients_when_user_has_billings_system_is_GB()
+        {
+            // Arrange
+            var user = new User
+            {
+                BillingEmails = "test@mail.com, test2@mail.com",
+                SapProperties = "{\"ContractCurrency\" : false,\"GovernmentAccount\" : false,\"Premium\" : false,\"Plus\" : false,\"ComercialPartner\" : false,\"MarketingPartner\" : false,\"OnBoarding\" : false,\"Layout\" : false,\"Datahub\" : false,\"PushNotification\" : false,\"ExclusiveIp\" : false,\"Advisory\" : false,\"Reports\" : false,\"SMS\" : false}",
+                IdResponsabileBilling = (int)ResponsabileBillingEnum.GB
+            };
+
+            var httpClientFactoryMock = new Mock<IHttpClientFactory>();
+            var httpMessageHandlerMock = new Mock<HttpMessageHandler>();
+
+            httpMessageHandlerMock.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent("")
+                });
+            var httpClient = new HttpClient(httpMessageHandlerMock.Object);
+            httpClientFactoryMock.Setup(_ => _.CreateClient(It.IsAny<string>()))
+                .Returns(httpClient);
+
+            var mockConnection = new Mock<DbConnection>();
+            mockConnection.SetupDapperAsync(c => c.QueryFirstOrDefaultAsync<User>(null, null, null, null, null))
+                .ReturnsAsync(user);
+
+            var client = _factory.WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    services.SetupConnectionFactory(mockConnection.Object);
+                    services.AddSingleton(Mock.Of<IEncryptionService>());
+                    services.AddSingleton(httpClientFactoryMock.Object);
+                });
+
+            }).CreateClient(new WebApplicationFactoryClientOptions());
+            var billingEmailRecipients = new EmailRecipients
+            {
+                Recipients = new[] { "test@mail.com", "test2@mail.com" }
+            };
+            var requestContent = new StringContent(JsonConvert.SerializeObject(billingEmailRecipients), Encoding.UTF8, "application/json");
+            var request = new HttpRequestMessage(HttpMethod.Put, "accounts/test1@test.com/billing-information/invoice-recipients")
+            {
+                Headers = { { "Authorization", $"Bearer {TOKEN_ACCOUNT_123_TEST1_AT_TEST_DOT_COM_EXPIRE_20330518}" } },
+                Content = requestContent
+            };
+
+            // Act
+            var response = await client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            httpMessageHandlerMock.Protected().Verify<Task<HttpResponseMessage>>("SendAsync", Times.Exactly(0),
+                ItExpr.Is<HttpRequestMessage>(
+                    req => req.Method == HttpMethod.Post
+                            && req.Content.ReadAsStringAsync().Result.Contains("\"BillingEmails\":[\"test@mail.com\",\"test2@mail.com\"]")
+                            && req.Content.ReadAsStringAsync().Result.Contains("\"BillingSystemId\":9")),
+                ItExpr.IsAny<CancellationToken>());
+        }
+    }
+}

--- a/Doppler.BillingUser/Controllers/BillingController.cs
+++ b/Doppler.BillingUser/Controllers/BillingController.cs
@@ -71,6 +71,15 @@ namespace Doppler.BillingUser.Controllers
         }
 
         [Authorize(Policies.OWN_RESOURCE_OR_SUPERUSER)]
+        [HttpPut("/accounts/{accountname}/billing-information/invoice-recipients")]
+        public async Task<IActionResult> UpdateInvoiceRecipients(string accountname, [FromBody] InvoiceRecipients invoiceRecipients)
+        {
+            await _billingRepository.UpdateInvoiceRecipients(accountname, invoiceRecipients.Recipients, invoiceRecipients.PlanId);
+
+            return new OkObjectResult("Successfully");
+        }
+
+        [Authorize(Policies.OWN_RESOURCE_OR_SUPERUSER)]
         [HttpGet("/accounts/{accountname}/payment-methods/current")]
         public async Task<IActionResult> GetCurrentPaymentMethod(string accountname)
         {

--- a/Doppler.BillingUser/Controllers/BillingController.cs
+++ b/Doppler.BillingUser/Controllers/BillingController.cs
@@ -14,12 +14,12 @@ namespace Doppler.BillingUser.Controllers
     public class BillingController
     {
         private readonly ILogger _logger;
-        private readonly BillingRepository _billingRepository;
+        private readonly IBillingRepository _billingRepository;
         private readonly IValidator<BillingInformation> _validator;
 
         public BillingController(
             ILogger<BillingController> logger,
-            BillingRepository billingRepository,
+            IBillingRepository billingRepository,
             IValidator<BillingInformation> validator)
         {
             _logger = logger;

--- a/Doppler.BillingUser/ExternalServices/Sap/SapHelper.cs
+++ b/Doppler.BillingUser/ExternalServices/Sap/SapHelper.cs
@@ -1,3 +1,4 @@
+using Doppler.BillingUser.Enums;
 using Doppler.BillingUser.Model;
 
 namespace Doppler.BillingUser.ExternalServices.Sap
@@ -13,6 +14,16 @@ namespace Doppler.BillingUser.ExternalServices.Sap
                 return user.BillingFirstName;
 
             return user.FirstName ?? string.Empty;
+        }
+
+        public static string GetBillingStateId(User user)
+        {
+            if (user.BillingStateCountryCode != "US")
+                return string.Empty;
+
+            SapDictionary.StatesDictionary.TryGetValue(user.IdBillingState, out var stateIdUs);
+
+            return !string.IsNullOrEmpty(stateIdUs) ? stateIdUs : "99";
         }
     }
 }

--- a/Doppler.BillingUser/Infrastructure/BillingRepository.cs
+++ b/Doppler.BillingUser/Infrastructure/BillingRepository.cs
@@ -149,6 +149,26 @@ WHERE U.Email = @email;",
             };
         }
 
+        public async Task UpdateInvoiceRecipients(string accountName, string[] emailRecipients, int planId)
+        {
+            using var connection = await _connectionFactory.GetConnection();
+
+            await connection.ExecuteAsync(@"
+UPDATE
+    [User]
+SET
+    BillingEmails = @emailRecipients
+WHERE
+    Email = @email;",
+                new
+                {
+                    @email = accountName,
+                    @emailRecipients = string.Join(",", emailRecipients)
+                });
+
+                await SendUserDataToSap(accountName, planId);
+        }
+
         public async Task<bool> UpdateCurrentPaymentMethod(string accountName, PaymentMethod paymentMethod)
         {
             using var connection = await _connectionFactory.GetConnection();
@@ -198,7 +218,7 @@ WHERE Email = @email;",
             }
 
             //Send BP to SAP
-            await SendUserDataToSap(user, paymentMethod);
+            await SendUserDataToSap(accountName, paymentMethod.IdSelectedPlan);
 
             return true;
         }
@@ -267,11 +287,11 @@ WHERE
             });
         }
 
-        private async Task SendUserDataToSap(User user, PaymentMethod paymentMethod)
+        private async Task SendUserDataToSap(string accountName, int planId)
         {
             using var connection = await _connectionFactory.GetConnection();
 
-            var userData = await connection.QueryFirstOrDefaultAsync<User>(@"
+            var user = await connection.QueryFirstOrDefaultAsync<User>(@"
 SELECT
     U.FirstName,
     U.IdUser,
@@ -297,7 +317,7 @@ SELECT
     BS.CountryCode as BillingStateCountryCode,
     U.PaymentMethod,
     (SELECT IdUserType FROM [UserTypesPlans] WHERE IdUserTypePlan = @idUserTypePlan) as IdUserType,
-    IdResponsabileBilling,
+    U.IdResponsabileBilling,
     U.IdBillingState,
     BS.Name as BillingStateName,
     U.BillingCity
@@ -310,49 +330,52 @@ LEFT JOIN
 LEFT JOIN
     [State] BS ON BS.IdState = U.IdBillingState
 WHERE
-    U.IdUser = @IdUser;",
+    U.Email = @accountName;",
                 new
                 {
-                    user.IdUser,
-                    @idUserTypePlan = paymentMethod.IdSelectedPlan
+                    accountName,
+                    @idUserTypePlan = planId
                 });
 
-            var sapDto = new SapBusinessPartner
+            if (user.IdResponsabileBilling is (int)ResponsabileBillingEnum.QBL or (int)ResponsabileBillingEnum.GBBISIDE)
             {
-                Id = user.IdUser,
-                IsClientManager = false
-            };
+                var sapDto = new SapBusinessPartner
+                {
+                    Id = user.IdUser,
+                    IsClientManager = false,
+                    BillingEmails = (user.BillingEmails ?? string.Empty).Replace(" ", string.Empty).Split(','),
+                    FirstName = SapHelper.GetFirstName(user),
+                    LastName = string.IsNullOrEmpty(user.RazonSocial) ? user.BillingLastName ?? "" : "",
+                    BillingAddress = user.BillingAddress ?? "",
+                    CityName = user.CityName ?? "",
+                    StateId = user.IdState,
+                    CountryCode = user.StateCountryCode ?? "",
+                    Address = user.Address ?? "",
+                    ZipCode = user.ZipCode ?? "",
+                    BillingZip = user.BillingZip ?? "",
+                    Email = user.Email,
+                    PhoneNumber = user.PhoneNumber ?? "",
+                    FederalTaxId = user.CUIT,
+                    IdConsumerType = user.IdConsumerType,
+                    Cancelated = user.IsCancelated,
+                    SapProperties = JsonConvert.DeserializeObject(user.SapProperties),
+                    Blocked = user.BlockedAccountNotPayed,
+                    IsInbound = user.IsInbound,
+                    BillingCountryCode = user.BillingStateCountryCode ?? "",
+                    PaymentMethod = user.PaymentMethod,
+                    PlanType = user.IdUserType,
+                    BillingSystemId = user.IdResponsabileBilling
+                };
 
-            sapDto.BillingEmails = (userData.BillingEmails ?? string.Empty).Replace(" ", string.Empty).Split(',');
-            sapDto.FirstName = SapHelper.GetFirstName(userData);
-            sapDto.LastName = string.IsNullOrEmpty(userData.RazonSocial) ? userData.BillingLastName ?? "" : "";
-            sapDto.BillingAddress = userData.BillingAddress ?? "";
-            sapDto.CityName = userData.CityName ?? "";
-            sapDto.StateId = userData.IdState;
-            sapDto.CountryCode = userData.StateCountryCode ?? "";
-            sapDto.Address = userData.Address ?? "";
-            sapDto.ZipCode = userData.ZipCode ?? "";
-            sapDto.BillingZip = userData.BillingZip ?? "";
-            sapDto.Email = userData.Email;
-            sapDto.PhoneNumber = userData.PhoneNumber ?? "";
-            sapDto.FederalTaxId = userData.IdConsumerType == (int)ConsumerTypeEnum.CF ? (paymentMethod.IdentificationNumber ?? userData.CUIT) : userData.CUIT;
-            sapDto.FederalTaxType = userData.IdConsumerType == (int)ConsumerTypeEnum.CF ? paymentMethod.IdentificationType : sapDto.FederalTaxType;
-            sapDto.IdConsumerType = userData.IdConsumerType;
-            sapDto.Cancelated = userData.IsCancelated;
-            sapDto.SapProperties = JsonConvert.DeserializeObject(userData.SapProperties);
-            sapDto.Blocked = userData.BlockedAccountNotPayed;
-            sapDto.IsInbound = userData.IsInbound;
-            sapDto.BillingCountryCode = userData.BillingStateCountryCode ?? "";
-            sapDto.PaymentMethod = userData.PaymentMethod;
-            sapDto.PlanType = userData.IdUserType;
-            sapDto.BillingSystemId = userData.IdResponsabileBilling;
-            sapDto.BillingStateId = ((sapDto.BillingSystemId == (int)ResponsabileBillingEnum.QBL || sapDto.BillingSystemId == (int)ResponsabileBillingEnum.QuickBookUSA) && sapDto.BillingCountryCode != "US") ? string.Empty
-                : (sapDto.BillingCountryCode == "US") ? (SapDictionary.StatesDictionary.TryGetValue(userData.IdBillingState, out string stateIdUs) ? stateIdUs : string.Empty)
-                : (SapDictionary.StatesDictionary.TryGetValue(userData.IdBillingState, out string stateId) ? stateId : "99");
-            sapDto.County = userData.BillingStateName ?? "";
-            sapDto.BillingCity = userData.BillingCity ?? "";
+                sapDto.BillingStateId = ((sapDto.BillingSystemId == (int)ResponsabileBillingEnum.QBL || sapDto.BillingSystemId == (int)ResponsabileBillingEnum.QuickBookUSA) && sapDto.BillingCountryCode != "US") ? string.Empty
+                    : (sapDto.BillingCountryCode == "US") ? (SapDictionary.StatesDictionary.TryGetValue(user.IdBillingState, out string stateIdUs) ? stateIdUs : string.Empty)
+                    : (SapDictionary.StatesDictionary.TryGetValue(user.IdBillingState, out string stateId) ? stateId : "99");
+                sapDto.County = user.BillingStateName ?? "";
+                sapDto.BillingCity = user.BillingCity ?? "";
 
-            await _sapService.SendUserDataToSap(sapDto);
+                await _sapService.SendUserDataToSap(sapDto);
+            }
+          
         }
     }
 }

--- a/Doppler.BillingUser/Infrastructure/BillingRepository.cs
+++ b/Doppler.BillingUser/Infrastructure/BillingRepository.cs
@@ -134,8 +134,10 @@ WHERE
             var user = await connection.QueryFirstOrDefaultAsync<User>(@"
 SELECT
     U.BillingEmails
-FROM [User] U
-WHERE U.Email = @email;",
+FROM
+    [User] U
+WHERE
+    U.Email = @email;",
                 new
                 {
                     @email = accountName
@@ -166,7 +168,7 @@ WHERE
                     @emailRecipients = string.Join(",", emailRecipients)
                 });
 
-                await SendUserDataToSap(accountName, planId);
+            await SendUserDataToSap(accountName, planId);
         }
 
         public async Task<bool> UpdateCurrentPaymentMethod(string accountName, PaymentMethod paymentMethod)
@@ -375,7 +377,6 @@ WHERE
 
                 await _sapService.SendUserDataToSap(sapDto);
             }
-          
         }
     }
 }

--- a/Doppler.BillingUser/Infrastructure/IBillingRepository.cs
+++ b/Doppler.BillingUser/Infrastructure/IBillingRepository.cs
@@ -14,5 +14,7 @@ namespace Doppler.BillingUser.Infrastructure
         Task<bool> UpdateCurrentPaymentMethod(string accountName, PaymentMethod paymentMethod);
 
         Task<EmailRecipients> GetInvoiceRecipients(string accountName);
+
+        Task UpdateInvoiceRecipients(string accountName, string[] emailRecipients, int planId);
     }
 }

--- a/Doppler.BillingUser/Infrastructure/InfrastructureServiceCollectionExtensions.cs
+++ b/Doppler.BillingUser/Infrastructure/InfrastructureServiceCollectionExtensions.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Extensions.DependencyInjection
     {
         public static IServiceCollection AddRepositories(this IServiceCollection services)
         {
-            services.AddScoped<BillingRepository, BillingRepository>();
+            services.AddScoped<IBillingRepository, BillingRepository>();
             services.AddScoped<IDatabaseConnectionFactory, DatabaseConnectionFactory>();
             return services;
         }

--- a/Doppler.BillingUser/Model/InvoiceRecipients.cs
+++ b/Doppler.BillingUser/Model/InvoiceRecipients.cs
@@ -1,0 +1,8 @@
+namespace Doppler.BillingUser.Model
+{
+    public class InvoiceRecipients
+    {
+        public int PlanId { get; set; }
+        public string[] Recipients { get; set; }
+    }
+}


### PR DESCRIPTION
# Background
We need to set email invoice recipients in User->BillingEmails and if correspond to send to SAP

Pseudocode:
if user is QBL or BBISIDE billing System, the system sends to sap with the information to create a new BP

contract:
```
accounts/{accountName}/billing-information/invoice-recipients (PUT) Body: {
   {
    "planId": 11,
    "recipients": [
        "test20@mailinator.com", 
        "test21@mailinator.com"
        ]
}
}
```