### PR TITLE
fix: [DAT-625] Fix Get email recipients empty

### DIFF
--- a/Doppler.BillingUser.Test/GetInvoiceRecipientsTest.cs
+++ b/Doppler.BillingUser.Test/GetInvoiceRecipientsTest.cs
@@ -71,7 +71,7 @@ namespace Doppler.BillingUser.Test
             {
                 BillingEmails = null
             };
-            const string expectedContent = "{\"recipients\":[\"\"]}";
+            const string expectedContent = "{\"recipients\":[]}";
 
             var mockConnection = new Mock<DbConnection>();
             mockConnection.SetupDapperAsync(c => c.QueryFirstOrDefaultAsync<User>(null, null, null, null, null))

--- a/Doppler.BillingUser/Infrastructure/BillingRepository.cs
+++ b/Doppler.BillingUser/Infrastructure/BillingRepository.cs
@@ -145,7 +145,7 @@ WHERE U.Email = @email;",
 
             return new EmailRecipients
             {
-                Recipients = (user.BillingEmails ?? string.Empty).Replace(" ", string.Empty).Split(',')
+                Recipients = string.IsNullOrEmpty(user.BillingEmails) ? Array.Empty<string>() : user.BillingEmails.Replace(" ", string.Empty).Split(',')
             };
         }
 


### PR DESCRIPTION
# Background
when user-> BillingEmails is empty, the get email recipients endpoint should be return [] by [""]

Example:
![image](https://user-images.githubusercontent.com/6796523/142673901-9728dfb8-2c28-475a-865f-7de92ac575b8.png)
