### PR TITLE
chore: allow to deal with plus symbol (+) in local IIS Express developer environment

### DIFF
--- a/Doppler.BillingUser/web.config
+++ b/Doppler.BillingUser/web.config
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <system.webServer>
+    <security>
+      <!--
+      It is to support plus symbol (+) in developer environment with IIS Express, it does not affect us in
+      unit tests or test or production environments because we are using Kestrel behind Traefik
+      -->
+      <requestFiltering allowDoubleEscaping="true" />
+    </security>
+  </system.webServer>
+</configuration>


### PR DESCRIPTION
Hi team!

We need to accept URLs like: `http://{host}/accounts/test1+extra@test.com/billing-information`

Right now we are getting this error:

![image](https://user-images.githubusercontent.com/1157864/143257851-42ebc055-c4c0-45a0-8dc5-d66d82cdac5e.png)

See [related chat](https://makingsense.slack.com/archives/CRXR62TC2/p1637329152092200).

Since in test and production environments we are using Linux containers with Kestrel behind Traefik, this change should not affect there. It neither affects our unit tests.

Probably we should apply this same patch in other projects.
