### PR TITLE
feat: [DAT-702] Save promotionId in billingCredits

### DIFF
--- a/Doppler.BillingUser.Test/PostAgreementTest.cs
+++ b/Doppler.BillingUser.Test/PostAgreementTest.cs
@@ -1,28 +1,18 @@
-using System.Data.Common;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Threading.Tasks;
-using Dapper;
 using Doppler.BillingUser.Encryption;
 using Doppler.BillingUser.ExternalServices.AccountPlansApi;
 using Doppler.BillingUser.Enums;
 using Doppler.BillingUser.ExternalServices.FirstData;
 using Doppler.BillingUser.Infrastructure;
 using Doppler.BillingUser.Model;
-using Doppler.BillingUser.Test.Utils;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
-using Moq.Dapper;
-using System.Data.Common;
-using System.Net;
-using System.Net.Http;
-using System.Net.Http.Headers;
-using System.Net.Http.Json;
-using System.Threading.Tasks;
 using Xunit;
 using System;
 
@@ -106,7 +96,8 @@ namespace Doppler.BillingUser.Test
             var accountPlansServiceMock = new Mock<IAccountPlansService>();
             accountPlansServiceMock.Setup(x => x.IsValidTotal(accountName, It.IsAny<AgreementInformation>()))
                 .ReturnsAsync(true);
-
+            accountPlansServiceMock.Setup(x => x.GetValidPromotionByCode(It.IsAny<string>(), It.IsAny<int>()))
+                .ReturnsAsync(new Promotion());
             var userRepositoryMock = new Mock<IUserRepository>();
             userRepositoryMock.Setup(x => x.GetUserBillingInformation(accountName))
                 .ReturnsAsync(new UserBillingInformation()
@@ -221,6 +212,8 @@ namespace Doppler.BillingUser.Test
             var accountPlansServiceMock = new Mock<IAccountPlansService>();
             accountPlansServiceMock.Setup(x => x.IsValidTotal(accountName, It.IsAny<AgreementInformation>()))
                 .ReturnsAsync(true);
+            accountPlansServiceMock.Setup(x => x.GetValidPromotionByCode(It.IsAny<string>(), It.IsAny<int>()))
+                .ReturnsAsync(new Promotion());
             var creditCard = new CreditCard()
             {
                 CardType = CardTypeEnum.Visa,
@@ -257,7 +250,12 @@ namespace Doppler.BillingUser.Test
 
             var billingRepositoryMock = new Mock<IBillingRepository>();
             billingRepositoryMock.Setup(x => x.CreateAccountingEntriesAsync(It.IsAny<AgreementInformation>(), It.IsAny<CreditCard>(), It.IsAny<int>(), It.IsAny<string>())).ReturnsAsync(invoiceId);
-            billingRepositoryMock.Setup(x => x.CreateBillingCreditAsync(It.IsAny<AgreementInformation>(), It.IsAny<UserBillingInformation>(), It.IsAny<UserTypePlanInformation>())).ReturnsAsync(billingCreditId);
+            billingRepositoryMock.Setup(x => x.CreateBillingCreditAsync(
+                    It.IsAny<AgreementInformation>(),
+                    It.IsAny<UserBillingInformation>(),
+                    It.IsAny<UserTypePlanInformation>(),
+                    It.IsAny<Promotion>()))
+                .ReturnsAsync(billingCreditId);
             billingRepositoryMock.Setup(x => x.CreateMovementCreditAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<UserBillingInformation>(), It.IsAny<UserTypePlanInformation>())).ReturnsAsync(movementCreditId);
 
             var client = _factory.WithWebHostBuilder(builder =>
@@ -371,15 +369,6 @@ namespace Doppler.BillingUser.Test
             var accountPlansServiceMock = new Mock<IAccountPlansService>();
             accountPlansServiceMock.Setup(x => x.IsValidTotal(accountName, It.IsAny<AgreementInformation>()))
                 .ReturnsAsync(true);
-            var creditCard = new CreditCard()
-            {
-                CardType = CardTypeEnum.Visa,
-                ExpirationMonth = 12,
-                ExpirationYear = 23,
-                HolderName = "kBvAJf5f3AIp8+MEVYVTGA==",
-                Number = "Oe9VdYnmPsZGPKnLEogk1hbP7NH3YfZnqxLrUJxnGgc=",
-                Code = "pNw3zrff06X9K972Ro6OwQ=="
-            };
 
             var userRepositoryMock = new Mock<IUserRepository>();
             userRepositoryMock.Setup(x => x.GetUserBillingInformation(accountName)).ReturnsAsync(user);
@@ -445,6 +434,8 @@ namespace Doppler.BillingUser.Test
             var accountPlansServiceMock = new Mock<IAccountPlansService>();
             accountPlansServiceMock.Setup(x => x.IsValidTotal(accountName, It.IsAny<AgreementInformation>()))
                 .ReturnsAsync(true);
+            accountPlansServiceMock.Setup(x => x.GetValidPromotionByCode(It.IsAny<string>(), It.IsAny<int>()))
+                .ReturnsAsync(new Promotion());
             var invoiceId = 1;
             var billingCreditId = 1;
             var movementCreditId = 1;
@@ -465,7 +456,12 @@ namespace Doppler.BillingUser.Test
 
             var billingRepositoryMock = new Mock<IBillingRepository>();
             billingRepositoryMock.Setup(x => x.CreateAccountingEntriesAsync(It.IsAny<AgreementInformation>(), It.IsAny<CreditCard>(), It.IsAny<int>(), It.IsAny<string>())).ReturnsAsync(invoiceId);
-            billingRepositoryMock.Setup(x => x.CreateBillingCreditAsync(It.IsAny<AgreementInformation>(), It.IsAny<UserBillingInformation>(), It.IsAny<UserTypePlanInformation>())).ReturnsAsync(billingCreditId);
+            billingRepositoryMock.Setup(x => x.CreateBillingCreditAsync(
+                    It.IsAny<AgreementInformation>(),
+                    It.IsAny<UserBillingInformation>(),
+                    It.IsAny<UserTypePlanInformation>(),
+                    It.IsAny<Promotion>()))
+                .ReturnsAsync(billingCreditId);
             billingRepositoryMock.Setup(x => x.CreateMovementCreditAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<UserBillingInformation>(), It.IsAny<UserTypePlanInformation>())).ReturnsAsync(movementCreditId);
 
             var client = _factory.WithWebHostBuilder(builder =>
@@ -758,6 +754,8 @@ namespace Doppler.BillingUser.Test
             var accountPlansServiceMock = new Mock<IAccountPlansService>();
             accountPlansServiceMock.Setup(x => x.IsValidTotal(accountName, It.IsAny<AgreementInformation>()))
                 .ReturnsAsync(true);
+            accountPlansServiceMock.Setup(x => x.GetValidPromotionByCode(It.IsAny<string>(), It.IsAny<int>()))
+                .ReturnsAsync(new Promotion());
             var invoiceId = 1;
             var billingCreditId = 1;
             var movementCreditId = 1;
@@ -778,7 +776,12 @@ namespace Doppler.BillingUser.Test
 
             var billingRepositoryMock = new Mock<IBillingRepository>();
             billingRepositoryMock.Setup(x => x.CreateAccountingEntriesAsync(It.IsAny<AgreementInformation>(), It.IsAny<CreditCard>(), It.IsAny<int>(), It.IsAny<string>())).ReturnsAsync(invoiceId);
-            billingRepositoryMock.Setup(x => x.CreateBillingCreditAsync(It.IsAny<AgreementInformation>(), It.IsAny<UserBillingInformation>(), It.IsAny<UserTypePlanInformation>())).ReturnsAsync(billingCreditId);
+            billingRepositoryMock.Setup(x => x.CreateBillingCreditAsync(
+                    It.IsAny<AgreementInformation>(),
+                    It.IsAny<UserBillingInformation>(),
+                    It.IsAny<UserTypePlanInformation>(),
+                    It.IsAny<Promotion>()))
+                .ReturnsAsync(billingCreditId);
             billingRepositoryMock.Setup(x => x.CreateMovementCreditAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<UserBillingInformation>(), It.IsAny<UserTypePlanInformation>())).ReturnsAsync(movementCreditId);
 
             var client = _factory.WithWebHostBuilder(builder =>
@@ -801,6 +804,157 @@ namespace Doppler.BillingUser.Test
             // Assert
             billingRepositoryMock.Verify(ms => ms.CreateAccountingEntriesAsync(It.IsAny<AgreementInformation>(), It.IsAny<CreditCard>(), It.IsAny<int>(), It.IsAny<string>()), Times.Never);
             billingRepositoryMock.Verify(ms => ms.CreateMovementCreditAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<UserBillingInformation>(), It.IsAny<UserTypePlanInformation>()), Times.Never);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        [Fact]
+        public async void POST_agreement_should_return_ok_when_promocode_is_null()
+        {
+            // Arrange
+            const string accountName = "test1@test.com";
+            var agreement = new
+            {
+                planId = 1,
+                total = 0
+            };
+            var billingRepositoryMock = new Mock<IBillingRepository>();
+            var accountPlansServiceMock = new Mock<IAccountPlansService>();
+            accountPlansServiceMock.Setup(x => x.IsValidTotal(accountName, It.IsAny<AgreementInformation>()))
+                .ReturnsAsync(true);
+            var userRepositoryMock = new Mock<IUserRepository>();
+            userRepositoryMock.Setup(x => x.GetUserBillingInformation(accountName))
+                .ReturnsAsync(new UserBillingInformation
+                {
+                    IdUser = 1,
+                    PaymentMethod = PaymentMethodEnum.CC
+                });
+            userRepositoryMock.Setup(x => x.GetUserNewTypePlan(It.IsAny<int>()))
+                .ReturnsAsync(new UserTypePlanInformation
+                {
+                    IdUserType = UserTypeEnum.INDIVIDUAL
+                });
+
+            var factory = _factory.WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    services.AddSingleton(Mock.Of<IEncryptionService>());
+                    services.AddSingleton(accountPlansServiceMock.Object);
+                    services.AddSingleton(userRepositoryMock.Object);
+                    services.AddSingleton(billingRepositoryMock.Object);
+                });
+
+            });
+            var client = factory.CreateClient(new WebApplicationFactoryClientOptions());
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", TOKEN_ACCOUNT123_TEST1_AT_TEST_DOT_COM_EXPIRE20330518);
+
+            // Act
+            var response = await client.PostAsJsonAsync($"accounts/{accountName}/agreements", agreement);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        [Fact]
+        public async void POST_agreement_should_return_bad_request_when_promocode_is_invalid()
+        {
+            // Arrange
+            const string accountName = "test1@test.com";
+            var agreement = new
+            {
+                planId = 1,
+                total = 0,
+                promocode = "promocode-test"
+            };
+            var billingRepositoryMock = new Mock<IBillingRepository>();
+            var accountPlansServiceMock = new Mock<IAccountPlansService>();
+            accountPlansServiceMock.Setup(x => x.IsValidTotal(accountName, It.IsAny<AgreementInformation>()))
+                .ReturnsAsync(true);
+            var userRepositoryMock = new Mock<IUserRepository>();
+            userRepositoryMock.Setup(x => x.GetUserBillingInformation(accountName))
+                .ReturnsAsync(new UserBillingInformation
+                {
+                    IdUser = 1,
+                    PaymentMethod = PaymentMethodEnum.CC
+                });
+            userRepositoryMock.Setup(x => x.GetUserNewTypePlan(It.IsAny<int>()))
+                .ReturnsAsync(new UserTypePlanInformation
+                {
+                    IdUserType = UserTypeEnum.INDIVIDUAL
+                });
+
+            var factory = _factory.WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    services.AddSingleton(Mock.Of<IEncryptionService>());
+                    services.AddSingleton(accountPlansServiceMock.Object);
+                    services.AddSingleton(userRepositoryMock.Object);
+                    services.AddSingleton(billingRepositoryMock.Object);
+                });
+
+            });
+            var client = factory.CreateClient(new WebApplicationFactoryClientOptions());
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", TOKEN_ACCOUNT123_TEST1_AT_TEST_DOT_COM_EXPIRE20330518);
+
+            // Act
+            var response = await client.PostAsJsonAsync($"accounts/{accountName}/agreements", agreement);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        }
+
+        [Fact]
+        public async void POST_agreement_should_return_ok_when_promocode_is_valid()
+        {
+            // Arrange
+            const string accountName = "test1@test.com";
+            var agreement = new
+            {
+                planId = 1,
+                total = 0,
+                promocode = "promocode-test"
+            };
+            var billingRepositoryMock = new Mock<IBillingRepository>();
+            var accountPlansServiceMock = new Mock<IAccountPlansService>();
+            accountPlansServiceMock.Setup(x => x.IsValidTotal(accountName, It.IsAny<AgreementInformation>()))
+                .ReturnsAsync(true);
+            accountPlansServiceMock.Setup(x => x.GetValidPromotionByCode("promocode-test", 1))
+                .ReturnsAsync(new Promotion
+                {
+                    IdPromotion = 1
+                });
+            var userRepositoryMock = new Mock<IUserRepository>();
+            userRepositoryMock.Setup(x => x.GetUserBillingInformation(accountName))
+                .ReturnsAsync(new UserBillingInformation
+                {
+                    IdUser = 1,
+                    PaymentMethod = PaymentMethodEnum.CC
+                });
+            userRepositoryMock.Setup(x => x.GetUserNewTypePlan(It.IsAny<int>()))
+                .ReturnsAsync(new UserTypePlanInformation
+                {
+                    IdUserType = UserTypeEnum.INDIVIDUAL
+                });
+
+            var factory = _factory.WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    services.AddSingleton(Mock.Of<IEncryptionService>());
+                    services.AddSingleton(accountPlansServiceMock.Object);
+                    services.AddSingleton(userRepositoryMock.Object);
+                    services.AddSingleton(billingRepositoryMock.Object);
+                });
+
+            });
+            var client = factory.CreateClient(new WebApplicationFactoryClientOptions());
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", TOKEN_ACCOUNT123_TEST1_AT_TEST_DOT_COM_EXPIRE20330518);
+
+            // Act
+            var response = await client.PostAsJsonAsync($"accounts/{accountName}/agreements", agreement);
+
+            // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         }
     }

--- a/Doppler.BillingUser/Controllers/BillingController.cs
+++ b/Doppler.BillingUser/Controllers/BillingController.cs
@@ -187,10 +187,10 @@ namespace Doppler.BillingUser.Controllers
                 return new BadRequestObjectResult("Invalid selected plan type");
             }
 
-            var promotion = await _accountPlansService.GetValidPromotionByCode(agreementInformation.Promocode, agreementInformation.PlanId);
-            if (!string.IsNullOrEmpty(agreementInformation.Promocode) && promotion == null)
+            Promotion promotion = null;
+            if(!string.IsNullOrEmpty(agreementInformation.Promocode))
             {
-                return new BadRequestObjectResult("Invalid promotion.");
+                promotion = await _accountPlansService.GetValidPromotionByCode(agreementInformation.Promocode, agreementInformation.PlanId);
             }
 
             if (agreementInformation.Total.GetValueOrDefault() > 0)

--- a/Doppler.BillingUser/Controllers/BillingController.cs
+++ b/Doppler.BillingUser/Controllers/BillingController.cs
@@ -188,7 +188,7 @@ namespace Doppler.BillingUser.Controllers
             }
 
             Promotion promotion = null;
-            if(!string.IsNullOrEmpty(agreementInformation.Promocode))
+            if (!string.IsNullOrEmpty(agreementInformation.Promocode))
             {
                 promotion = await _accountPlansService.GetValidPromotionByCode(agreementInformation.Promocode, agreementInformation.PlanId);
             }

--- a/Doppler.BillingUser/ExternalServices/AccountPlansApi/AccountPlansService.cs
+++ b/Doppler.BillingUser/ExternalServices/AccountPlansApi/AccountPlansService.cs
@@ -67,9 +67,8 @@ namespace Doppler.BillingUser.ExternalServices.AccountPlansApi
             catch (Exception e)
             {
                 _logger.LogError(e, $"Error to get promocode information {promocode}.");
+                throw;
             }
-
-            return null;
         }
     }
 }

--- a/Doppler.BillingUser/ExternalServices/AccountPlansApi/AccountPlansService.cs
+++ b/Doppler.BillingUser/ExternalServices/AccountPlansApi/AccountPlansService.cs
@@ -55,6 +55,7 @@ namespace Doppler.BillingUser.ExternalServices.AccountPlansApi
         {
             try
             {
+                // TODO: in the future, consider validating a signed token in place of request to the AccountPlanAPI
                 var promotion = await _flurlClient.Request(new UriTemplate(_options.Value.GetPromoCodeTemplate)
                     .AddParameter("planId", planId)
                     .AddParameter("promocode", promocode)

--- a/Doppler.BillingUser/ExternalServices/AccountPlansApi/AccountPlansSettings.cs
+++ b/Doppler.BillingUser/ExternalServices/AccountPlansApi/AccountPlansSettings.cs
@@ -3,5 +3,6 @@ namespace Doppler.BillingUser.ExternalServices.AccountPlansApi
     public class AccountPlansSettings
     {
         public string CalculateUrlTemplate { get; set; }
+        public string GetPromoCodeTemplate { get; set; }
     }
 }

--- a/Doppler.BillingUser/ExternalServices/AccountPlansApi/IAccountPlansService.cs
+++ b/Doppler.BillingUser/ExternalServices/AccountPlansApi/IAccountPlansService.cs
@@ -6,5 +6,6 @@ namespace Doppler.BillingUser.ExternalServices.AccountPlansApi
     public interface IAccountPlansService
     {
         public Task<bool> IsValidTotal(string accountname, AgreementInformation agreementInformation);
+        Task<Promotion> GetValidPromotionByCode(string promocode, int planId);
     }
 }

--- a/Doppler.BillingUser/Infrastructure/BillingRepository.cs
+++ b/Doppler.BillingUser/Infrastructure/BillingRepository.cs
@@ -527,7 +527,11 @@ SELECT CAST(SCOPE_IDENTITY() AS INT)",
             return invoiceId;
         }
 
-        public async Task<int> CreateBillingCreditAsync(AgreementInformation agreementInformation, UserBillingInformation user, UserTypePlanInformation newUserTypePlan)
+        public async Task<int> CreateBillingCreditAsync(
+            AgreementInformation agreementInformation,
+            UserBillingInformation user,
+            UserTypePlanInformation newUserTypePlan,
+            Promotion promotion)
         {
             var currentPaymentMethod = await GetCurrentPaymentMethod(user.Email);
             var buyCreditAgreement = new CreateAgreement
@@ -609,7 +613,8 @@ INSERT INTO [dbo].[BillingCredits]
     [IdResponsabileBilling],
     [CCIdentificationType],
     [CCIdentificationNumber],
-    [ResponsableIVA])
+    [ResponsableIVA],
+    [IdPromotion])
 VALUES (
     @date,
     @idUser,
@@ -649,7 +654,8 @@ VALUES (
     @idResponsabileBilling,
     @ccIdentificationType,
     @ccIdentificationNumber,
-    @responsableIVA);
+    @responsableIVA,
+    @IdPromotion);
 SELECT CAST(SCOPE_IDENTITY() AS INT)",
             new
             {
@@ -693,7 +699,8 @@ SELECT CAST(SCOPE_IDENTITY() AS INT)",
                 @idResponsabileBilling = (int)ResponsabileBillingEnum.QBL,
                 @ccIdentificationType = buyCreditAgreement.CCIdentificationType,
                 @ccIdentificationNumber = buyCreditAgreement.CCIdentificationNumber,
-                @responsableIVA = buyCreditAgreement.ResponsableIVA
+                @responsableIVA = buyCreditAgreement.ResponsableIVA,
+                @idPromotion = promotion?.IdPromotion
             });
 
             return result;

--- a/Doppler.BillingUser/Infrastructure/IBillingRepository.cs
+++ b/Doppler.BillingUser/Infrastructure/IBillingRepository.cs
@@ -21,7 +21,7 @@ namespace Doppler.BillingUser.Infrastructure
         Task<int> CreateAccountingEntriesAsync(AgreementInformation agreementInformation, CreditCard encryptedCreditCard, int userId, string authorizationNumber);
         Task<CurrentPlan> GetCurrentPlan(string accountName);
 
-        Task<int> CreateBillingCreditAsync(AgreementInformation agreementInformation, UserBillingInformation user, UserTypePlanInformation newUserTypePlan);
+        Task<int> CreateBillingCreditAsync(AgreementInformation agreementInformation, UserBillingInformation user, UserTypePlanInformation newUserTypePlan, Promotion promotion);
 
         Task<int> CreateMovementCreditAsync(int idBillingCredit, int partialBalance, UserBillingInformation user, UserTypePlanInformation newUserTypePlan);
     }

--- a/Doppler.BillingUser/Model/Promotion.cs
+++ b/Doppler.BillingUser/Model/Promotion.cs
@@ -1,0 +1,7 @@
+namespace Doppler.BillingUser.Model
+{
+    public class Promotion
+    {
+        public int IdPromotion { get; set; }
+    }
+}

--- a/Doppler.BillingUser/appsettings.Development.json
+++ b/Doppler.BillingUser/appsettings.Development.json
@@ -47,6 +47,7 @@
     "ReplyToAddress": "support@fromdoppler.com"
   },
   "AccountPlansSettings": {
-    "CalculateUrlTemplate": "http://localhost:5000/accounts/{accountname}/newplan/{planId}/calculate"
+    "CalculateUrlTemplate": "http://localhost:5000/accounts/{accountname}/newplan/{planId}/calculate",
+    "GetPromoCodeTemplate": "http://localhost:5000/plans/{planId}/validate/{promocode}"
   }
 }

--- a/Doppler.BillingUser/appsettings.int.json
+++ b/Doppler.BillingUser/appsettings.int.json
@@ -1,5 +1,6 @@
 {
   "AccountPlansSettings": {
-    "CalculateUrlTemplate": "https://apisint.fromdoppler.net/doppler-account-plans/accounts/{accountname}/newplan/{planId}/calculate"
+    "CalculateUrlTemplate": "https://apisint.fromdoppler.net/doppler-account-plans/accounts/{accountname}/newplan/{planId}/calculate",
+    "GetPromoCodeTemplate": "https://apisint.fromdoppler.net/doppler-account-plans/plans/{planId}/validate/{promocode}"
   }
 }

--- a/Doppler.BillingUser/appsettings.json
+++ b/Doppler.BillingUser/appsettings.json
@@ -52,6 +52,7 @@
     "ReplyToAddress": "support@fromdoppler.com"
   },
   "AccountPlansSettings": {
-    "CalculateUrlTemplate": "https://apis.fromdoppler.com/doppler-account-plans/accounts/{accountname}/newplan/{planId}/calculate"
+    "CalculateUrlTemplate": "https://apis.fromdoppler.com/doppler-account-plans/accounts/{accountname}/newplan/{planId}/calculate",
+    "GetPromoCodeTemplate": "https://apis.fromdoppler.com/doppler-account-plans/plans/{planId}/validate/{promocode}"
   }
 }

--- a/Doppler.BillingUser/appsettings.qa.json
+++ b/Doppler.BillingUser/appsettings.qa.json
@@ -1,5 +1,6 @@
 {
   "AccountPlansSettings": {
-    "CalculateUrlTemplate": "https://apisqa.fromdoppler.net/doppler-account-plans/accounts/{accountname}/newplan/{planId}/calculate"
+    "CalculateUrlTemplate": "https://apisqa.fromdoppler.net/doppler-account-plans/accounts/{accountname}/newplan/{planId}/calculate",
+    "GetPromoCodeTemplate": "https://apisqa.fromdoppler.net/doppler-account-plans/plans/{planId}/validate/{promocode}"
   }
 }


### PR DESCRIPTION
# background
We need to save the IdPromotion in BillingCredits table when the user buys a new plan with promocode valid

![promocodeCheck](https://user-images.githubusercontent.com/6796523/146257306-f8dc34a8-35a5-4c6b-956b-a445ccf8ef8d.png)


Steps:
1- The user clicks on the Buy button, the system triggers a POST request to Billing user API
2- Billing user API make a request of the promocode values of agreement, sending a GET request to Account Plans API
3- Account plans API processes the petition, getting the promocode of agreement with information saved in the Doppler database
4- Account plans API return promocode information to Billing API user to use these values
5- Billing user API saves the promocodeId in the billing credit table
6- Billing user API sends reponse to WebApp