### PR TITLE
[DAT-708] - Add email notification when the credits purchase is successful

### DIFF
--- a/Doppler.BillingUser.Test/PostAgreementTest.cs
+++ b/Doppler.BillingUser.Test/PostAgreementTest.cs
@@ -19,6 +19,9 @@ using Flurl.Http.Testing;
 using Doppler.BillingUser.ExternalServices.Sap;
 using Doppler.BillingUser.ExternalServices.Slack;
 using Microsoft.Extensions.Options;
+using Doppler.BillingUser.ExternalServices.EmailSender;
+using System.Collections.Generic;
+using System.Threading;
 
 namespace Doppler.BillingUser.Test
 {
@@ -115,6 +118,10 @@ namespace Doppler.BillingUser.Test
                 IdUserType = UserTypeEnum.INDIVIDUAL
             });
             userRepositoryMock.Setup(x => x.GetEncryptedCreditCard(It.IsAny<string>())).ReturnsAsync(creditCard);
+            userRepositoryMock.Setup(x => x.GetUserInformation(It.IsAny<string>())).ReturnsAsync(new User()
+            {
+                Language = "es"
+            });
 
             var paymentGatewayMock = new Mock<IPaymentGateway>();
             paymentGatewayMock.Setup(x => x.CreateCreditCardPayment(It.IsAny<decimal>(), It.IsAny<CreditCard>(), It.IsAny<int>())).ReturnsAsync(authorizatioNumber);
@@ -129,6 +136,9 @@ namespace Doppler.BillingUser.Test
 
             var sapServiceMock = new Mock<ISapService>();
             sapServiceMock.Setup(x => x.SendBillingToSap(It.IsAny<SapBillingDto>(), It.IsAny<string>()));
+
+            var emailSenderMock = new Mock<IEmailSender>();
+            emailSenderMock.Setup(x => x.SafeSendWithTemplateAsync(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<IEnumerable<string>>(), It.IsAny<IEnumerable<string>>(), It.IsAny<IEnumerable<string>>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<Attachment>>(), It.IsAny<CancellationToken>()));
 
             var encryptionServiceMock = new Mock<IEncryptionService>();
             encryptionServiceMock.Setup(x => x.DecryptAES256(It.IsAny<string>())).Returns("12345");
@@ -260,6 +270,10 @@ namespace Doppler.BillingUser.Test
             userRepositoryMock.Setup(x => x.GetEncryptedCreditCard(It.IsAny<string>())).ReturnsAsync(creditCard);
             userRepositoryMock.Setup(x => x.UpdateUserBillingCredit(It.IsAny<UserBillingInformation>())).ReturnsAsync(1);
             userRepositoryMock.Setup(x => x.GetAvailableCredit(It.IsAny<int>())).ReturnsAsync(10);
+            userRepositoryMock.Setup(x => x.GetUserInformation(It.IsAny<string>())).ReturnsAsync(new User()
+            {
+                Language = "es"
+            });
 
             var paymentGatewayMock = new Mock<IPaymentGateway>();
             paymentGatewayMock.Setup(x => x.CreateCreditCardPayment(It.IsAny<decimal>(), It.IsAny<CreditCard>(), It.IsAny<int>())).ReturnsAsync(authorizatioNumber);
@@ -281,6 +295,9 @@ namespace Doppler.BillingUser.Test
 
             var sapServiceMock = new Mock<ISapService>();
             sapServiceMock.Setup(x => x.SendBillingToSap(It.IsAny<SapBillingDto>(), It.IsAny<string>()));
+
+            var emailSenderMock = new Mock<IEmailSender>();
+            emailSenderMock.Setup(x => x.SafeSendWithTemplateAsync(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<IEnumerable<string>>(), It.IsAny<IEnumerable<string>>(), It.IsAny<IEnumerable<string>>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<Attachment>>(), It.IsAny<CancellationToken>()));
 
             var encryptionServiceMock = new Mock<IEncryptionService>();
             encryptionServiceMock.Setup(x => x.DecryptAES256(It.IsAny<string>())).Returns("12345");
@@ -490,6 +507,13 @@ namespace Doppler.BillingUser.Test
                     It.IsAny<Promotion>()))
                 .ReturnsAsync(billingCreditId);
             billingRepositoryMock.Setup(x => x.CreateMovementCreditAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<UserBillingInformation>(), It.IsAny<UserTypePlanInformation>())).ReturnsAsync(movementCreditId);
+            userRepositoryMock.Setup(x => x.GetUserInformation(It.IsAny<string>())).ReturnsAsync(new User()
+            {
+                Language = "es"
+            });
+
+            var emailSenderMock = new Mock<IEmailSender>();
+            emailSenderMock.Setup(x => x.SafeSendWithTemplateAsync(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<IEnumerable<string>>(), It.IsAny<IEnumerable<string>>(), It.IsAny<IEnumerable<string>>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<Attachment>>(), It.IsAny<CancellationToken>()));
 
             var client = _factory.WithWebHostBuilder(builder =>
             {
@@ -812,6 +836,10 @@ namespace Doppler.BillingUser.Test
             });
             userRepositoryMock.Setup(x => x.UpdateUserBillingCredit(It.IsAny<UserBillingInformation>())).ReturnsAsync(1);
             userRepositoryMock.Setup(x => x.GetAvailableCredit(It.IsAny<int>())).ReturnsAsync(10);
+            userRepositoryMock.Setup(x => x.GetUserInformation(It.IsAny<string>())).ReturnsAsync(new User()
+            {
+                Language = "es"
+            });
 
             var billingRepositoryMock = new Mock<IBillingRepository>();
             billingRepositoryMock.Setup(x => x.CreateAccountingEntriesAsync(It.IsAny<AgreementInformation>(), It.IsAny<CreditCard>(), It.IsAny<int>(), It.IsAny<string>())).ReturnsAsync(invoiceId);
@@ -822,6 +850,9 @@ namespace Doppler.BillingUser.Test
                     It.IsAny<Promotion>()))
                 .ReturnsAsync(billingCreditId);
             billingRepositoryMock.Setup(x => x.CreateMovementCreditAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<UserBillingInformation>(), It.IsAny<UserTypePlanInformation>())).ReturnsAsync(movementCreditId);
+
+            var emailSenderMock = new Mock<IEmailSender>();
+            emailSenderMock.Setup(x => x.SafeSendWithTemplateAsync(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<IEnumerable<string>>(), It.IsAny<IEnumerable<string>>(), It.IsAny<IEnumerable<string>>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<Attachment>>(), It.IsAny<CancellationToken>()));
 
             var client = _factory.WithWebHostBuilder(builder =>
             {
@@ -876,6 +907,11 @@ namespace Doppler.BillingUser.Test
                 });
             userRepositoryMock.Setup(x => x.GetEncryptedCreditCard(It.IsAny<string>()))
                 .ReturnsAsync(new CreditCard());
+            userRepositoryMock.Setup(x => x.GetUserInformation(It.IsAny<string>())).ReturnsAsync(new User()
+            {
+                Language = "es"
+            });
+
             var paymentGatewayMock = new Mock<IPaymentGateway>();
             paymentGatewayMock.Setup(x => x.CreateCreditCardPayment(
                     It.IsAny<decimal>(),
@@ -885,6 +921,9 @@ namespace Doppler.BillingUser.Test
 
             var sapServiceMock = new Mock<ISapService>();
             sapServiceMock.Setup(x => x.SendBillingToSap(It.IsAny<SapBillingDto>(), It.IsAny<string>()));
+
+            var emailSenderMock = new Mock<IEmailSender>();
+            emailSenderMock.Setup(x => x.SafeSendWithTemplateAsync(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<IEnumerable<string>>(), It.IsAny<IEnumerable<string>>(), It.IsAny<IEnumerable<string>>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<Attachment>>(), It.IsAny<CancellationToken>()));
 
             var encryptionServiceMock = new Mock<IEncryptionService>();
             encryptionServiceMock.Setup(x => x.DecryptAES256(It.IsAny<string>())).Returns("12345");
@@ -995,6 +1034,14 @@ namespace Doppler.BillingUser.Test
                 {
                     IdUserType = UserTypeEnum.INDIVIDUAL
                 });
+            userRepositoryMock.Setup(x => x.GetUserInformation(It.IsAny<string>())).ReturnsAsync(new User()
+            {
+                Language = "es"
+            });
+
+            var emailSenderMock = new Mock<IEmailSender>();
+            emailSenderMock.Setup(x => x.SafeSendWithTemplateAsync(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<IEnumerable<string>>(), It.IsAny<IEnumerable<string>>(), It.IsAny<IEnumerable<string>>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<Attachment>>(), It.IsAny<CancellationToken>()));
+
             var factory = _factory.WithWebHostBuilder(builder =>
             {
                 builder.ConfigureTestServices(services =>
@@ -1048,6 +1095,14 @@ namespace Doppler.BillingUser.Test
                 {
                     IdUserType = UserTypeEnum.INDIVIDUAL
                 });
+            userRepositoryMock.Setup(x => x.GetUserInformation(It.IsAny<string>())).ReturnsAsync(new User()
+            {
+                Language = "es"
+            });
+
+            var emailSenderMock = new Mock<IEmailSender>();
+            emailSenderMock.Setup(x => x.SafeSendWithTemplateAsync(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<IEnumerable<string>>(), It.IsAny<IEnumerable<string>>(), It.IsAny<IEnumerable<string>>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<Attachment>>(), It.IsAny<CancellationToken>()));
+
             var promotionRepositoryMock = new Mock<IPromotionRepository>();
             var factory = _factory.WithWebHostBuilder(builder =>
             {

--- a/Doppler.BillingUser.Test/PostAgreementTest.cs
+++ b/Doppler.BillingUser.Test/PostAgreementTest.cs
@@ -153,6 +153,7 @@ namespace Doppler.BillingUser.Test
                     services.AddSingleton(paymentGatewayMock.Object);
                     services.AddSingleton(billingRepositoryMock.Object);
                     services.AddSingleton(sapServiceMock.Object);
+                    services.AddSingleton(emailSenderMock.Object);
                 });
             }).CreateClient(new WebApplicationFactoryClientOptions());
             client.DefaultRequestHeaders.Add("Authorization", $"Bearer {TOKEN_ACCOUNT123_TEST1_AT_TEST_DOT_COM_EXPIRE20330518}");
@@ -311,6 +312,7 @@ namespace Doppler.BillingUser.Test
                     services.AddSingleton(userRepositoryMock.Object);
                     services.AddSingleton(paymentGatewayMock.Object);
                     services.AddSingleton(billingRepositoryMock.Object);
+                    services.AddSingleton(emailSenderMock.Object);
                 });
 
             }).CreateClient(new WebApplicationFactoryClientOptions());
@@ -523,6 +525,7 @@ namespace Doppler.BillingUser.Test
                     services.AddSingleton(accountPlansServiceMock.Object);
                     services.AddSingleton(userRepositoryMock.Object);
                     services.AddSingleton(billingRepositoryMock.Object);
+                    services.AddSingleton(emailSenderMock.Object);
                 });
 
             }).CreateClient(new WebApplicationFactoryClientOptions());
@@ -862,6 +865,7 @@ namespace Doppler.BillingUser.Test
                     services.AddSingleton(accountPlansServiceMock.Object);
                     services.AddSingleton(userRepositoryMock.Object);
                     services.AddSingleton(billingRepositoryMock.Object);
+                    services.AddSingleton(emailSenderMock.Object);
                 });
 
             }).CreateClient(new WebApplicationFactoryClientOptions());
@@ -937,6 +941,7 @@ namespace Doppler.BillingUser.Test
                     services.AddSingleton(billingRepositoryMock.Object);
                     services.AddSingleton(paymentGatewayMock.Object);
                     services.AddSingleton(sapServiceMock.Object);
+                    services.AddSingleton(emailSenderMock.Object);
                 });
 
             });
@@ -1051,6 +1056,7 @@ namespace Doppler.BillingUser.Test
                     services.AddSingleton(userRepositoryMock.Object);
                     services.AddSingleton(billingRepositoryMock.Object);
                     services.AddSingleton(Mock.Of<IPromotionRepository>());
+                    services.AddSingleton(emailSenderMock.Object);
                 });
             });
             var client = factory.CreateClient(new WebApplicationFactoryClientOptions());
@@ -1113,6 +1119,7 @@ namespace Doppler.BillingUser.Test
                     services.AddSingleton(userRepositoryMock.Object);
                     services.AddSingleton(billingRepositoryMock.Object);
                     services.AddSingleton(promotionRepositoryMock.Object);
+                    services.AddSingleton(emailSenderMock.Object);
                 });
             });
             var client = factory.CreateClient(new WebApplicationFactoryClientOptions());

--- a/Doppler.BillingUser/Controllers/BillingController.cs
+++ b/Doppler.BillingUser/Controllers/BillingController.cs
@@ -308,7 +308,7 @@ namespace Doppler.BillingUser.Controllers
                             isPaymentMethodCC = user.PaymentMethod == PaymentMethodEnum.CC,
                             isPaymentMethodMP = user.PaymentMethod == PaymentMethodEnum.MP,
                             isPaymentMethodTransf = user.PaymentMethod == PaymentMethodEnum.TRANSF,
-                            availableCreditsQty = partialBalance,
+                            availableCreditsQty = partialBalance + newPlan.EmailQty + (promotion != null ? promotion.ExtraCredits ?? 0 : 0),
                             year = DateTime.UtcNow.Year
                         },
                         to: new[] { accountname });
@@ -321,7 +321,7 @@ namespace Doppler.BillingUser.Controllers
                         {
                             urlImagesBase = _emailSettings.Value.UrlEmailImagesBase,
                             user = accountname,
-                            client = string.Format($"{userInformation.FirstName} {userInformation.LastName}"),
+                            client = $"{userInformation.FirstName} {userInformation.LastName}",
                             address = userInformation.Address,
                             phone = userInformation.PhoneNumber,
                             company = userInformation.Company,

--- a/Doppler.BillingUser/Controllers/BillingController.cs
+++ b/Doppler.BillingUser/Controllers/BillingController.cs
@@ -15,6 +15,8 @@ using Doppler.BillingUser.Encryption;
 using System.Linq;
 using Doppler.BillingUser.ExternalServices.Slack;
 using Microsoft.Extensions.Options;
+using Doppler.BillingUser.ExternalServices.EmailSender;
+using Doppler.BillingUser.Utils;
 
 namespace Doppler.BillingUser.Controllers
 {
@@ -29,6 +31,8 @@ namespace Doppler.BillingUser.Controllers
         private readonly IAccountPlansService _accountPlansService;
         private readonly IValidator<AgreementInformation> _agreementInformationValidator;
         private readonly IPaymentGateway _paymentGateway;
+        private readonly IEmailSender _emailSender;
+        private readonly IOptions<EmailNotificationsConfiguration> _emailSettings;
         private readonly ISapService _sapService;
         private readonly IEncryptionService _encryptionService;
         private readonly IOptions<SapSettings> _sapSettings;
@@ -48,7 +52,9 @@ namespace Doppler.BillingUser.Controllers
             IEncryptionService encryptionService,
             IOptions<SapSettings> sapSettings,
             IPromotionRepository promotionRepository,
-            ISlackService slackService)
+            ISlackService slackService,
+            IEmailSender emailSender,
+            IOptions<EmailNotificationsConfiguration> emailSettings)
         {
             _logger = logger;
             _billingRepository = billingRepository;
@@ -58,6 +64,8 @@ namespace Doppler.BillingUser.Controllers
             _accountPlansService = accountPlansService;
             _paymentGateway = paymentGateway;
             _sapService = sapService;
+            _emailSender = emailSender;
+            _emailSettings = emailSettings;
             _encryptionService = encryptionService;
             _sapSettings = sapSettings;
             _promotionRepository = promotionRepository;
@@ -282,7 +290,78 @@ namespace Doppler.BillingUser.Controllers
                         accountname);
                 }
 
-                // TODO: SEND NOTIFICATIONS
+                User userInformation = await _userRepository.GetUserInformation(accountname);
+                var template = _emailSettings.Value.CreditsApprovedTemplateId[userInformation.Language ?? "en"];
+
+                await _emailSender.SafeSendWithTemplateAsync(
+                        templateId: template,
+                        templateModel: new
+                        {
+                            urlImagesBase = _emailSettings.Value.UrlEmailImagesBase,
+                            firstName = userInformation.FirstName,
+                            isIndividualPlan = newPlan.IdUserType == UserTypeEnum.INDIVIDUAL,
+                            isMonthlyPlan = newPlan.IdUserType == UserTypeEnum.MONTHLY,
+                            isSubscribersPlan = newPlan.IdUserType == UserTypeEnum.SUBSCRIBERS,
+                            creditsQty = newPlan.EmailQty,
+                            subscribersQty = newPlan.Subscribers,
+                            amount = newPlan.Fee,
+                            isPaymentMethodCC = user.PaymentMethod == PaymentMethodEnum.CC,
+                            isPaymentMethodMP = user.PaymentMethod == PaymentMethodEnum.MP,
+                            isPaymentMethodTransf = user.PaymentMethod == PaymentMethodEnum.TRANSF,
+                            availableCreditsQty = partialBalance,
+                            year = DateTime.UtcNow.Year
+                        },
+                        to: new[] { accountname });
+
+                var templateAdmin = _emailSettings.Value.CreditsApprovedAdminTemplateId;
+
+                await _emailSender.SafeSendWithTemplateAsync(
+                        templateId: templateAdmin,
+                        templateModel: new
+                        {
+                            urlImagesBase = _emailSettings.Value.UrlEmailImagesBase,
+                            user = accountname,
+                            client = string.Format($"{userInformation.FirstName} {userInformation.LastName}"),
+                            address = userInformation.Address,
+                            phone = userInformation.PhoneNumber,
+                            company = userInformation.Company,
+                            city = userInformation.CityName,
+                            state = userInformation.BillingStateName,
+                            zipCode = userInformation.ZipCode,
+                            language = userInformation.Language,
+                            country = userInformation.BillingCountryName,
+                            vendor = userInformation.Vendor,
+                            promotionCode = agreementInformation.Promocode,
+                            promotionCodeDiscount = promotion?.DiscountPlanFee,
+                            promotionCodeExtraCredits = promotion?.ExtraCredits,
+                            razonSocial = userInformation.RazonSocial,
+                            cuit = userInformation.CUIT,
+                            isConsumerCF = userInformation.IdConsumerType == (int)ConsumerTypeEnum.CF,
+                            isConsumerRFC = userInformation.IdConsumerType == (int)ConsumerTypeEnum.RFC,
+                            isConsumerRI = userInformation.IdConsumerType == (int)ConsumerTypeEnum.RI,
+                            isCfdiUseG03 = user.CFDIUse == "G03",
+                            isCfdiUseP01 = user.CFDIUse == "P01",
+                            isPaymentTypePPD = user.PaymentType == "PPD",
+                            isPaymentTypePUE = user.PaymentType == "PUE",
+                            isPaymentWayCash = user.PaymentWay == "CASH",
+                            isPaymentWayCheck = user.PaymentWay == "CHECK",
+                            isPaymentWayTransfer = user.PaymentWay == "TRANSFER",
+                            bankName = user.BankName,
+                            bankAccount = user.BankAccount,
+                            billingEmails = userInformation.BillingEmails,
+                            //userMessage = user.ExclusiveMessage, //TODO: set when the property is set in BilligCredit
+                            isIndividualPlan = newPlan.IdUserType == UserTypeEnum.INDIVIDUAL,
+                            isMonthlyPlan = newPlan.IdUserType == UserTypeEnum.MONTHLY,
+                            isSubscribersPlan = newPlan.IdUserType == UserTypeEnum.SUBSCRIBERS,
+                            creditsQty = newPlan.EmailQty,
+                            subscribersQty = newPlan.Subscribers,
+                            amount = newPlan.Fee,
+                            isPaymentMethodCC = user.PaymentMethod == PaymentMethodEnum.CC,
+                            isPaymentMethodMP = user.PaymentMethod == PaymentMethodEnum.MP,
+                            isPaymentMethodTransf = user.PaymentMethod == PaymentMethodEnum.TRANSF,
+                            year = DateTime.UtcNow.Year
+                        },
+                        to: new[] { _emailSettings.Value.AdminEmail });
 
                 var message = $"Successful at creating a new agreement for: User: {accountname} - Plan: {agreementInformation.PlanId}";
                 await _slackService.SendNotification(message + (!string.IsNullOrEmpty(agreementInformation.Promocode) ? $" - Promocode {agreementInformation.Promocode}" : string.Empty));

--- a/Doppler.BillingUser/ExternalServices/EmailSender/EmailNotificationsConfiguration.cs
+++ b/Doppler.BillingUser/ExternalServices/EmailSender/EmailNotificationsConfiguration.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+namespace Doppler.BillingUser.ExternalServices.EmailSender
+{
+    public class EmailNotificationsConfiguration
+    {
+        public string AdminEmail { get; set; }
+        public Dictionary<string, string> CreditsApprovedTemplateId { get; set; }
+        public string CreditsApprovedAdminTemplateId { get; set; }
+        public string UrlEmailImagesBase { get; set; }
+    }
+}

--- a/Doppler.BillingUser/ExternalServices/EmailSender/RelayEmailSenderSettings.cs
+++ b/Doppler.BillingUser/ExternalServices/EmailSender/RelayEmailSenderSettings.cs
@@ -2,7 +2,6 @@ namespace Doppler.BillingUser.ExternalServices.EmailSender
 {
     public class RelayEmailSenderSettings
     {
-        public string SendUrlTemplate { get; set; }
         public string SendTemplateUrlTemplate { get; set; }
         public string ApiKey { get; set; }
         public int AccountId { get; set; }

--- a/Doppler.BillingUser/Infrastructure/IUserRepository.cs
+++ b/Doppler.BillingUser/Infrastructure/IUserRepository.cs
@@ -12,5 +12,6 @@ namespace Doppler.BillingUser.Infrastructure
         Task<UserTypePlanInformation> GetUserNewTypePlan(int idUserTypePlan);
         Task<int> UpdateUserBillingCredit(UserBillingInformation user);
         Task<int> GetAvailableCredit(int idUser);
+        Task<User> GetUserInformation(string accountName);
     }
 }

--- a/Doppler.BillingUser/Infrastructure/UserRepository.cs
+++ b/Doppler.BillingUser/Infrastructure/UserRepository.cs
@@ -102,7 +102,8 @@ SELECT
     [EmailQty],
     [Fee],
     [ExtraEmailCost],
-    [SubscribersQty]
+    [SubscribersQty],
+    [Description] as Subscribers
 FROM
     [dbo].[UserTypesPlans]
 WHERE
@@ -157,6 +158,46 @@ DESC",
                 });
 
             return partialBalance;
+        }
+
+        public async Task<User> GetUserInformation(string accountName)
+        {
+            using var connection = await _connectionFactory.GetConnection();
+            var user = await connection.QueryFirstOrDefaultAsync<User>(@"
+SELECT
+    U.FirstName,
+    U.LastName,
+    U.Address,
+    U.PhoneNumber,
+    U.Company,
+    U.CityName,
+    BS.Name as BillingStateName,
+    U.ZipCode,
+    L.Name as Language,
+    C.Name as BillingCountryName,
+    V.Fullname as Vendor,
+    U.CUIT,
+    U.RazonSocial,
+    U.IdConsumerType,
+    U.BillingEmails
+FROM
+    [User] U
+LEFT JOIN
+    [Vendor] V ON V.IdVendor = U.IdVendor
+LEFT JOIN
+    [State] BS ON BS.IdState = U.IdBillingState
+LEFT JOIN
+    [Country] C ON C.IdCountry = BS.IdCountry
+INNER JOIN
+    Language L ON U.IdLanguage = L.IdLanguage
+WHERE
+    U.Email = @accountName;",
+                new
+                {
+                    accountName
+                });
+
+            return user;
         }
     }
 }

--- a/Doppler.BillingUser/Model/Promotion.cs
+++ b/Doppler.BillingUser/Model/Promotion.cs
@@ -5,5 +5,6 @@ namespace Doppler.BillingUser.Model
         public int IdPromotion { get; set; }
 
         public int? ExtraCredits { get; set; }
+        public int? DiscountPlanFee { get; set; }
     }
 }

--- a/Doppler.BillingUser/Model/User.cs
+++ b/Doppler.BillingUser/Model/User.cs
@@ -3,6 +3,7 @@ namespace Doppler.BillingUser.Model
     public class User
     {
         public string FirstName { get; set; }
+        public string LastName { get; set; }
         public int IdUser { get; set; }
         public string BillingEmails { get; set; }
         public string RazonSocial { get; set; }
@@ -34,8 +35,12 @@ namespace Doppler.BillingUser.Model
         public int IdUserType { get; set; }
         //Vendor
         public bool IsInbound { get; set; }
+        public string Vendor { get; set; }
         //BillingState
         public string BillingStateCountryCode { get; set; }
         public string BillingStateName { get; set; }
+        public string Company { get; set; }
+        public string Language { get; set; }
+        public string BillingCountryName { get; set; }
     }
 }

--- a/Doppler.BillingUser/Model/UserTypePlanInformation.cs
+++ b/Doppler.BillingUser/Model/UserTypePlanInformation.cs
@@ -10,5 +10,6 @@ namespace Doppler.BillingUser.Model
         public double? Fee { get; set; }
         public double? ExtraEmailCost { get; set; }
         public int? SubscribersQty { get; set; }
+        public string? Subscribers { get; set; }
     }
 }

--- a/Doppler.BillingUser/Startup.cs
+++ b/Doppler.BillingUser/Startup.cs
@@ -35,6 +35,7 @@ namespace Doppler.BillingUser
         {
             services.Configure<DopplerDatabaseSettings>(Configuration.GetSection(nameof(DopplerDatabaseSettings)));
             services.Configure<RelayEmailSenderSettings>(Configuration.GetSection(nameof(RelayEmailSenderSettings)));
+            services.Configure<EmailNotificationsConfiguration>(Configuration.GetSection(nameof(EmailNotificationsConfiguration)));
             services.AddDopplerSecurity();
             services.AddRepositories();
             services.AddControllers();
@@ -93,6 +94,7 @@ namespace Doppler.BillingUser
             services.AddSingleton<IFlurlClientFactory, PerBaseUrlFlurlClientFactory>();
             services.AddScoped<IPromotionRepository, PromotionRepository>();
             services.Configure<SlackSettings>(Configuration.GetSection(nameof(SlackSettings)));
+            services.AddTransient<IEmailSender, RelayEmailSender>();
             services.AddScoped<ISlackService, SlackService>();
         }
 

--- a/Doppler.BillingUser/appsettings.Development.json
+++ b/Doppler.BillingUser/appsettings.Development.json
@@ -36,15 +36,19 @@
     "TimeZoneOffset": "-3"
   },
   "RelayEmailSenderSettings": {
-    "SendTemplateUrlTemplate": "http://int-api-relay.fromdoppler.net/accounts/{accountId}/templates/{templateId}/message",
-    "SendUrlTemplate": "http://int-api-relay.fromdoppler.net/accounts/{accountId}/messages",
-    "ApiKey": "REPLACE_FOR_EMAIL_SENDER_API_KEY",
-    "AccountId": 73,
-    "AccountName": "fromdoppler",
-    "Username": "easla@fromdoppler.com",
-    "FromName": "Doppler",
-    "FromAddress": "info@fromdoppler.com",
-    "ReplyToAddress": "support@fromdoppler.com"
+    "ApiKey": "gsjkvp80qgzuyeg56yndi0e5hl13cy",
+    "AccountId": 151,
+    "AccountName": "testrelay",
+    "Username": "dopplerrelay+test@makingsense.com",
+    "FromAddress": "dopplerrelay+test@makingsense.com"
+  },
+  "EmailNotificationsConfiguration": {
+    "AdminEmail": "bamaro@makingsense.com",
+    "CreditsApprovedTemplateId": {
+      "es": "a8d0afca-f8e8-4ef0-be1a-1ec3edacbe51",
+      "en": "3b1da2c0-124f-4df9-b588-ef54e8e9aec8"
+    },
+    "CreditsApprovedAdminTemplateId": "0bc86e98-0e96-4f5f-be67-f62e17b46afa"
   },
   "AccountPlansSettings": {
     "CalculateUrlTemplate": "http://localhost:5000/accounts/{accountname}/newplan/{planId}/calculate?discountId={discountId}&promocode={promocode}",

--- a/Doppler.BillingUser/appsettings.Development.json
+++ b/Doppler.BillingUser/appsettings.Development.json
@@ -36,7 +36,6 @@
     "TimeZoneOffset": "-3"
   },
   "RelayEmailSenderSettings": {
-    "ApiKey": "gsjkvp80qgzuyeg56yndi0e5hl13cy",
     "AccountId": 151,
     "AccountName": "testrelay",
     "Username": "dopplerrelay+test@makingsense.com",

--- a/Doppler.BillingUser/appsettings.int.json
+++ b/Doppler.BillingUser/appsettings.int.json
@@ -7,7 +7,8 @@
     "ApiKey": "gsjkvp80qgzuyeg56yndi0e5hl13cy",
     "AccountId": 151,
     "AccountName": "testrelay",
-    "Username": "dopplerrelay+test@makingsense.com"
+    "Username": "dopplerrelay+test@makingsense.com",
+    "FromAddress": "dopplerrelay+test@makingsense.com"
   },
   "EmailNotificationsConfiguration": {
     "AdminEmail": "bamaro@makingsense.com",

--- a/Doppler.BillingUser/appsettings.int.json
+++ b/Doppler.BillingUser/appsettings.int.json
@@ -2,5 +2,19 @@
   "AccountPlansSettings": {
     "CalculateUrlTemplate": "https://apisint.fromdoppler.net/doppler-account-plans/accounts/{accountname}/newplan/{planId}/calculate?discountId={discountId}&promocode={promocode}",
     "GetPromoCodeTemplate": "https://apisint.fromdoppler.net/doppler-account-plans/plans/{planId}/validate/{promocode}"
+  },
+  "RelayEmailSenderSettings": {
+    "ApiKey": "gsjkvp80qgzuyeg56yndi0e5hl13cy",
+    "AccountId": 151,
+    "AccountName": "testrelay",
+    "Username": "dopplerrelay+test@makingsense.com"
+  },
+  "EmailNotificationsConfiguration": {
+    "AdminEmail": "bamaro@makingsense.com",
+    "CreditsApprovedTemplateId": {
+      "es": "a8d0afca-f8e8-4ef0-be1a-1ec3edacbe51",
+      "en": "3b1da2c0-124f-4df9-b588-ef54e8e9aec8"
+    },
+    "CreditsApprovedAdminTemplateId": "0bc86e98-0e96-4f5f-be67-f62e17b46afa"
   }
 }

--- a/Doppler.BillingUser/appsettings.int.json
+++ b/Doppler.BillingUser/appsettings.int.json
@@ -4,7 +4,6 @@
     "GetPromoCodeTemplate": "https://apisint.fromdoppler.net/doppler-account-plans/plans/{planId}/validate/{promocode}"
   },
   "RelayEmailSenderSettings": {
-    "ApiKey": "gsjkvp80qgzuyeg56yndi0e5hl13cy",
     "AccountId": 151,
     "AccountName": "testrelay",
     "Username": "dopplerrelay+test@makingsense.com",

--- a/Doppler.BillingUser/appsettings.json
+++ b/Doppler.BillingUser/appsettings.json
@@ -41,8 +41,7 @@
     "TimeZoneOffset": "-3"
   },
   "RelayEmailSenderSettings": {
-    "SendTemplateUrlTemplate": "http://int-api-relay.fromdoppler.net/accounts/{accountId}/templates/{templateId}/message",
-    "SendUrlTemplate": "http://int-api-relay.fromdoppler.net/accounts/{accountId}/messages",
+    "SendTemplateUrlTemplate": "https://api.dopplerrelay.com/accounts/{accountId}/templates/{templateId}/message",
     "ApiKey": "REPLACE_FOR_EMAIL_SENDER_API_KEY",
     "AccountId": 73,
     "AccountName": "fromdoppler",
@@ -50,6 +49,15 @@
     "FromName": "Doppler",
     "FromAddress": "info@fromdoppler.com",
     "ReplyToAddress": "support@fromdoppler.com"
+  },
+  "EmailNotificationsConfiguration": {
+    "AdminEmail": "upgrade@makingsense.com",
+    "CreditsApprovedTemplateId": {
+      "es": "TEMPLATE_PROD_ES",
+      "en": "TEMPLATE_PROD_EN"
+    },
+    "CreditsApprovedAdminTemplateId": "TEMPLATE_PROD_ADMIN",
+    "UrlEmailImagesBase": "http://app2.fromdoppler.com/img/Email"
   },
   "AccountPlansSettings": {
     "CalculateUrlTemplate": "https://apis.fromdoppler.com/doppler-account-plans/accounts/{accountname}/newplan/{planId}/calculate?discountId={discountId}&promocode={promocode}",

--- a/Doppler.BillingUser/appsettings.qa.json
+++ b/Doppler.BillingUser/appsettings.qa.json
@@ -4,7 +4,6 @@
     "GetPromoCodeTemplate": "https://apisqa.fromdoppler.net/doppler-account-plans/plans/{planId}/validate/{promocode}"
   },
   "RelayEmailSenderSettings": {
-    "ApiKey": "gsjkvp80qgzuyeg56yndi0e5hl13cy",
     "AccountId": 151,
     "AccountName": "testrelay",
     "Username": "dopplerrelay+test@makingsense.com",

--- a/Doppler.BillingUser/appsettings.qa.json
+++ b/Doppler.BillingUser/appsettings.qa.json
@@ -2,5 +2,20 @@
   "AccountPlansSettings": {
     "CalculateUrlTemplate": "https://apisqa.fromdoppler.net/doppler-account-plans/accounts/{accountname}/newplan/{planId}/calculate?discountId={discountId}&promocode={promocode}",
     "GetPromoCodeTemplate": "https://apisqa.fromdoppler.net/doppler-account-plans/plans/{planId}/validate/{promocode}"
+  },
+  "RelayEmailSenderSettings": {
+    "ApiKey": "gsjkvp80qgzuyeg56yndi0e5hl13cy",
+    "AccountId": 151,
+    "AccountName": "testrelay",
+    "Username": "dopplerrelay+test@makingsense.com",
+    "FromAddress": "dopplerrelay+test@makingsense.com"
+  },
+  "EmailNotificationsConfiguration": {
+    "AdminEmail": "bamaro@makingsense.com",
+    "CreditsApprovedTemplateId": {
+      "es": "a8d0afca-f8e8-4ef0-be1a-1ec3edacbe51",
+      "en": "3b1da2c0-124f-4df9-b588-ef54e8e9aec8"
+    },
+    "CreditsApprovedAdminTemplateId": "0bc86e98-0e96-4f5f-be67-f62e17b46afa"
   }
 }


### PR DESCRIPTION
Here we are adding the sending of email by Relay email sender to the User and to the Admin when a credits purchase is sucessfull. Three templates have been created in Relay, in the test user: dopplerrelay+test@makingsense.com

- Credits approved to User in english: **3b1da2c0-124f-4df9-b588-ef54e8e9aec8**
- Credits approved to User in spanish: **a8d0afca-f8e8-4ef0-be1a-1ec3edacbe51**
- Credits approved to Admin (is always in spanish): **0bc86e98-0e96-4f5f-be67-f62e17b46afa**

WIP: unit test missing