### PR TITLE
[DAT-708]: Change admin email in QA env

### DIFF
--- a/Doppler.BillingUser/appsettings.qa.json
+++ b/Doppler.BillingUser/appsettings.qa.json
@@ -10,7 +10,7 @@
     "FromAddress": "dopplerrelay+test@makingsense.com"
   },
   "EmailNotificationsConfiguration": {
-    "AdminEmail": "bamaro@makingsense.com",
+    "AdminEmail": "soporte@fromdoppler.com",
     "CreditsApprovedTemplateId": {
       "es": "a8d0afca-f8e8-4ef0-be1a-1ec3edacbe51",
       "en": "3b1da2c0-124f-4df9-b588-ef54e8e9aec8"


### PR DESCRIPTION
Here we are changing the account Admin for QA environment, in order to the people that make the tests can check it.