### PR TITLE
Dat 625 billing user api   integrar con zoho

### DIFF
--- a/Doppler.BillingUser.Test/ZohoServiceTest.cs
+++ b/Doppler.BillingUser.Test/ZohoServiceTest.cs
@@ -1,0 +1,54 @@
+using Doppler.BillingUser.ExternalServices.Zoho;
+using Flurl.Http.Configuration;
+using Flurl.Http.Testing;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Doppler.BillingUser.Test
+{
+    public class ZohoServiceTest : IClassFixture<WebApplicationFactory<Startup>>
+    {
+        [Fact]
+        public async Task Send_lead_update_to_zoho_when_request_body_has_all_values_ok()
+        {
+            // Arrange
+            var leadId = "991102004120214390";
+            var url = $"https://www.zohoapis.com/crm/v2/Leads/{leadId}";
+            var body = "{\"data\":[{\"First_Name\":\"Nombre\",\"Last_Name\":\"Apellido\",\"Email\":\"test@test.com\",\"Lead_Source\":\"Admin\",\"Phone\":\"54 266 431-4463\",\"Country\":\"Argentina\",\"Doppler\":\"Individual\",\"D_Created_Date\":\"2021-08-19T15:36:51Z\",\"D_Status\":\"Active\",\"D_First_Payment\":\"2022-01-11T19:20:39Z\",\"D_Billing_System\":\"CC\",\"D_Origin\":\"login\",\"D_Origin_Cookies\":\"login\",\"D_Upgrade_Date\":\"2022-01-11T19:20:39Z\",\"D_UserId\":309929,\"D_Confirmation\":\"2021-08-19T15:37:16Z\",\"D_Last_Login_2\":\"2022-01-07T13:03:20Z\",\"D_Cant_Login\":5,\"D_Campa_as\":0,\"D_Creacion_lista\":\"No\",\"D_Integraciones\":\"No\",\"D_DKIM_SPF\":\"No\",\"Capsulas\":0,\"D_Domain_Score2\":0,\"D_Last_Price_Visit\":\"2021-08-19T15:40:08Z\",\"D_Cant_Visits_Prices\":2,\"UTM_Source\":\"direct\",\"UTM_Cookie1\":\"Date: 8/19/2021 3:35:52 PM +00:00, UTMSource: direct, UTMMedium: , UTMCampaign: , UTMTerm: , UTMContent:\",\"D_Primera_Base\":0,\"Lim500free\":\"No\",\"id\":\"119045987120124320\",\"owner\":{\"id\":\"198002440035064001\",\"name\":\"Nombre Apellido\",\"email\":\"ddonofrio@makingsense.com\"},\"Created_By\":{\"id\":\"198002440035064001\",\"name\":\"Nombre Apellido\",\"email\":\"ddonofrio@makingsense.com\"},\"Modified_By\":{\"id\":\"198002440035064001\",\"name\":\"Nombre Apellido\",\"email\":\"ddonofrio@makingsense.com\"},\"Created_Time\":\"2021-08-19T15:37:17Z\",\"Modified_Time\":\"2022-01-10T14:29:39Z\",\"Last_Activity_Time\":\"2022-01-10T14:29:39Z\"}]}";
+
+            var service = new ZohoService(
+                GetZohoServiceSettingsMock().Object,
+                new PerBaseUrlFlurlClientFactory());
+
+            using var httpTest = new HttpTest();
+
+            //Act
+            await service.UpdateZohoEntityAsync(body, leadId, "Leads");
+
+            // Assert
+            httpTest
+                .ShouldHaveCalled(url)
+                .WithVerb(HttpMethod.Put)
+                .WithRequestBody(body)
+                .Times(1);
+        }
+
+        private static Mock<IOptions<ZohoSettings>> GetZohoServiceSettingsMock()
+        {
+            var zohoSettingsMock = new Mock<IOptions<ZohoSettings>>();
+            zohoSettingsMock.Setup(x => x.Value)
+                .Returns(new ZohoSettings
+                {
+                    UseZoho = true,
+                    BaseUrl = "https://www.zohoapis.com/crm/v2/"
+                });
+
+            return zohoSettingsMock;
+        }
+    }
+}

--- a/Doppler.BillingUser/ExternalServices/Zoho/API/ZohoEntityAccount.cs
+++ b/Doppler.BillingUser/ExternalServices/Zoho/API/ZohoEntityAccount.cs
@@ -1,0 +1,152 @@
+using Newtonsoft.Json;
+using System;
+
+namespace Doppler.BillingUser.ExternalServices.Zoho.API
+{
+    public class ZohoEntityAccount : ZohoEntityBase
+    {
+        [JsonProperty(PropertyName = "First_Name")]
+        public string FirstName { get; set; }
+
+        [JsonProperty(PropertyName = "Account_Name")]
+        public string AccountName { get; set; }
+
+        [JsonProperty(PropertyName = "Last_Name")]
+        public string LastName { get; set; }
+
+        [JsonProperty(PropertyName = "Email")]
+        public string Email { get; set; }
+
+        [JsonProperty(PropertyName = "Title")]
+        public string Title { get; set; }
+
+        [JsonProperty(PropertyName = "Lead_Source")]
+        public string Source { get; set; }
+
+        [JsonProperty(PropertyName = "Company")]
+        public string Company { get; set; }
+
+        [JsonProperty(PropertyName = "Phone")]
+        public string PhoneNumber { get; set; }
+
+        [JsonProperty(PropertyName = "Mobile")]
+        public string MobileNumber { get; set; }
+
+        [JsonProperty(PropertyName = "Street")]
+        public string Street { get; set; }
+
+        [JsonProperty(PropertyName = "City")]
+        public string City { get; set; }
+
+        [JsonProperty(PropertyName = "Country")]
+        public string Country { get; set; }
+
+        [JsonProperty(PropertyName = "State")]
+        public string State { get; set; }
+
+        [JsonProperty(PropertyName = "Zip")]
+        public string Zip { get; set; }
+
+        [JsonProperty(PropertyName = "Salutation")]
+        public string Salutation { get; set; }
+
+        [JsonProperty(PropertyName = "Website")]
+        public string Website { get; set; }
+
+        [JsonProperty(PropertyName = "Doppler")]
+        public string Doppler { get; set; }
+
+        [JsonProperty(PropertyName = "D_Created_Date")]
+        public DateTime? DCreatedDate { get; set; }
+
+        [JsonProperty(PropertyName = "D_Status")]
+        public string DStatus { get; set; }
+
+        [JsonProperty(PropertyName = "D_First_Payment")]
+        public DateTime? DFirstPayment { get; set; }
+
+        [JsonProperty(PropertyName = "D_DiscountType")]
+        public string DDiscountType { get; set; }
+
+        [JsonProperty(PropertyName = "D_DiscountTypeDesc")]
+        public string DDiscountTypeDesc { get; set; }
+
+        [JsonProperty(PropertyName = "D_Billing_System")]
+        public string DBillingSystem { get; set; }
+
+        [JsonProperty(PropertyName = "D_Origin")]
+        public string DOrigin { get; set; }
+
+        [JsonProperty(PropertyName = "D_Origin_Cookies")]
+        public string DOriginCookies { get; set; }
+
+        [JsonProperty(PropertyName = "D_Upgrade_Date")]
+        public DateTime? DUpgradeDate { get; set; }
+
+        [JsonProperty(PropertyName = "D_UserId")]
+        public int? DUserId { get; set; }
+
+        [JsonProperty(PropertyName = "D_PromoCode")]
+        public string DPromoCode { get; set; }
+
+        [JsonProperty(PropertyName = "D_Confirmation")]
+        public DateTime? DConfirmation { get; set; }
+
+        [JsonProperty(PropertyName = "D_Last_Login_2")]
+        public DateTime? DLastLogin { get; set; }
+
+        [JsonProperty(PropertyName = "D_Cant_Login")]
+        public int? DCantLogin { get; set; }
+
+        [JsonProperty(PropertyName = "D_Campa_as")]
+        public int? DCampaigns { get; set; }
+
+        [JsonProperty(PropertyName = "D_Creacion_lista")]
+        public string DListCreated { get; set; }
+
+        [JsonProperty(PropertyName = "Industria")]
+        public string Industry { get; set; }
+
+        [JsonProperty(PropertyName = "D_Integraciones")]
+        public string DIntegraciones { get; set; }
+
+        [JsonProperty(PropertyName = "D_DKIM_SPF")]
+        public string DDkimSpf { get; set; }
+
+        [JsonProperty(PropertyName = "Capsulas")]
+        public int? Capsulas { get; set; }
+
+        [JsonProperty(PropertyName = "D_Domain_Score2")]
+        public int? DDomainScore { get; set; }
+
+        [JsonProperty(PropertyName = "D_Last_Price_Visit")]
+        public DateTime? DLastPriceVisit { get; set; }
+
+        [JsonProperty(PropertyName = "D_Cant_Visits_Prices")]
+        public int? DCantVisitsPrices { get; set; }
+
+        [JsonProperty(PropertyName = "UTM_Source")]
+        public string UTMSource { get; set; }
+
+        [JsonProperty(PropertyName = "UTM_Medium")]
+        public string UTMMedium { get; set; }
+
+        [JsonProperty(PropertyName = "UTM_Campaign")]
+        public string UTMCampaign { get; set; }
+
+        [JsonProperty(PropertyName = "UTM_Term")]
+        public string UTMTerm { get; set; }
+
+        [JsonProperty(PropertyName = "UTM_Cookie1")]
+        public string UTMCookies { get; set; }
+
+        [JsonProperty(PropertyName = "D_Primera_Base")]
+        public int DCantSubscribers { get; set; }
+
+        [JsonProperty(PropertyName = "Lim500free")]
+        public string Limit500Free { get; set; }
+
+        [JsonProperty(PropertyName = "Origin_Inbound")]
+        public string OriginInbound { get; set; }
+    }
+}

--- a/Doppler.BillingUser/ExternalServices/Zoho/API/ZohoEntityBase.cs
+++ b/Doppler.BillingUser/ExternalServices/Zoho/API/ZohoEntityBase.cs
@@ -1,0 +1,40 @@
+using Newtonsoft.Json;
+using System;
+
+namespace Doppler.BillingUser.ExternalServices.Zoho.API
+{
+
+    public class ZohoDopplerValues
+    {
+        public const string Free = "Free";
+        public const string Active = "Active";
+        public const string Inactive = "Inactive";
+        public const string Discount = "% Discount";
+        public const string Credits = "Extra Credits";
+
+    }
+    public class ZohoEntityBase
+    {
+        [JsonProperty(PropertyName = "id")]
+        public string Id { get; set; }
+
+        [JsonProperty(PropertyName = "owner")]
+        public ZohoUser Owner { get; set; }
+
+        [JsonProperty(PropertyName = "Created_By")]
+        public ZohoUser CreatedBy { get; set; }
+
+        [JsonProperty(PropertyName = "Modified_By")]
+        public ZohoUser ModifiedBy { get; set; }
+
+        [JsonProperty(PropertyName = "Created_Time")]
+        public DateTime? CreatedTime { get; set; }
+
+        [JsonProperty(PropertyName = "Modified_Time")]
+        public DateTime? ModifiedTime { get; set; }
+
+        [JsonProperty(PropertyName = "Last_Activity_Time")]
+        public DateTime? LastActivityTime { get; set; }
+
+    }
+}

--- a/Doppler.BillingUser/ExternalServices/Zoho/API/ZohoEntityContact.cs
+++ b/Doppler.BillingUser/ExternalServices/Zoho/API/ZohoEntityContact.cs
@@ -1,0 +1,55 @@
+using Newtonsoft.Json;
+
+namespace Doppler.BillingUser.ExternalServices.Zoho.API
+{
+    public class ZohoEntityContact : ZohoEntityBase
+    {
+        [JsonProperty(PropertyName = "First_Name")]
+        public string FirstName { get; set; }
+
+        [JsonProperty(PropertyName = "Account_Name")]
+        public ZohoUser AccountName { get; set; }
+
+        [JsonProperty(PropertyName = "Last_Name")]
+        public string LastName { get; set; }
+
+        [JsonProperty(PropertyName = "Email")]
+        public string Email { get; set; }
+
+        [JsonProperty(PropertyName = "Title")]
+        public string Title { get; set; }
+
+        [JsonProperty(PropertyName = "Lead_Source")]
+        public string Source { get; set; }
+
+        [JsonProperty(PropertyName = "Company")]
+        public string Company { get; set; }
+
+        [JsonProperty(PropertyName = "Phone")]
+        public string PhoneNumber { get; set; }
+
+        [JsonProperty(PropertyName = "Mobile")]
+        public string MobileNumber { get; set; }
+
+        [JsonProperty(PropertyName = "Street")]
+        public string Street { get; set; }
+
+        [JsonProperty(PropertyName = "City")]
+        public string City { get; set; }
+
+        [JsonProperty(PropertyName = "Country")]
+        public string Country { get; set; }
+
+        [JsonProperty(PropertyName = "State")]
+        public string State { get; set; }
+
+        [JsonProperty(PropertyName = "Zip")]
+        public string Zip { get; set; }
+
+        [JsonProperty(PropertyName = "Salutation")]
+        public string Salutation { get; set; }
+
+        [JsonProperty(PropertyName = "Website")]
+        public string Website { get; set; }
+    }
+}

--- a/Doppler.BillingUser/ExternalServices/Zoho/API/ZohoEntityLead.cs
+++ b/Doppler.BillingUser/ExternalServices/Zoho/API/ZohoEntityLead.cs
@@ -1,0 +1,152 @@
+using Newtonsoft.Json;
+using System;
+
+namespace Doppler.BillingUser.ExternalServices.Zoho.API
+{
+    public class ZohoEntityLead : ZohoEntityBase
+    {
+        [JsonProperty(PropertyName = "First_Name")]
+        public string FirstName { get; set; }
+
+        [JsonProperty(PropertyName = "Last_Name")]
+        public string LastName { get; set; }
+
+        [JsonProperty(PropertyName = "Email")]
+        public string Email { get; set; }
+
+        [JsonProperty(PropertyName = "Title")]
+        public string Title { get; set; }
+
+        [JsonProperty(PropertyName = "Lead_Source")]
+        public string Source { get; set; }
+
+        [JsonProperty(PropertyName = "Company")]
+        public string Company { get; set; }
+
+        [JsonProperty(PropertyName = "Phone")]
+        public string PhoneNumber { get; set; }
+
+        [JsonProperty(PropertyName = "Mobile")]
+        public string MobileNumber { get; set; }
+
+        [JsonProperty(PropertyName = "Street")]
+        public string Street { get; set; }
+
+        [JsonProperty(PropertyName = "City")]
+        public string City { get; set; }
+
+        [JsonProperty(PropertyName = "Country")]
+        public string Country { get; set; }
+
+        [JsonProperty(PropertyName = "State")]
+        public string State { get; set; }
+
+        [JsonProperty(PropertyName = "Zip")]
+        public string Zip { get; set; }
+
+        [JsonProperty(PropertyName = "Salutation")]
+        public string Salutation { get; set; }
+
+        [JsonProperty(PropertyName = "Website")]
+        public string Website { get; set; }
+
+        [JsonProperty(PropertyName = "Doppler")]
+        public string Doppler { get; set; }
+
+        [JsonProperty(PropertyName = "D_Created_Date")]
+        public DateTime? DCreatedDate { get; set; }
+
+        [JsonProperty(PropertyName = "D_Status")]
+        public string DStatus { get; set; }
+
+        [JsonProperty(PropertyName = "D_First_Payment")]
+        public DateTime? DFirstPayment { get; set; }
+
+        [JsonProperty(PropertyName = "D_DiscountType")]
+        public string DDiscountType { get; set; }
+
+        [JsonProperty(PropertyName = "D_DiscountTypeDesc")]
+        public string DDiscountTypeDesc { get; set; }
+
+        [JsonProperty(PropertyName = "D_Billing_System")]
+        public string DBillingSystem { get; set; }
+
+        [JsonProperty(PropertyName = "D_Origin")]
+        public string DOrigin { get; set; }
+
+        [JsonProperty(PropertyName = "D_Origin_Cookies")]
+        public string DOriginCookies { get; set; }
+
+        [JsonProperty(PropertyName = "D_Upgrade_Date")]
+        public DateTime? DUpgradeDate { get; set; }
+
+        [JsonProperty(PropertyName = "D_UserId")]
+        public int? DUserId { get; set; }
+
+        [JsonProperty(PropertyName = "D_PromoCode")]
+        public string DPromoCode { get; set; }
+
+        [JsonProperty(PropertyName = "D_Confirmation")]
+        public DateTime? DConfirmation { get; set; }
+
+        [JsonProperty(PropertyName = "D_Last_Login_2")]
+        public DateTime? DLastLogin { get; set; }
+
+        [JsonProperty(PropertyName = "D_Cant_Login")]
+        public int? DCantLogin { get; set; }
+
+        [JsonProperty(PropertyName = "D_Campa_as")]
+        public int? DCampaigns { get; set; }
+
+        [JsonProperty(PropertyName = "D_Creacion_lista")]
+        public string DListCreated { get; set; }
+
+        [JsonProperty(PropertyName = "Industria")]
+        public string Industry { get; set; }
+
+        [JsonProperty(PropertyName = "D_Integraciones")]
+        public string DIntegraciones { get; set; }
+
+        [JsonProperty(PropertyName = "D_DKIM_SPF")]
+        public string DDkimSpf { get; set; }
+
+        [JsonProperty(PropertyName = "Capsulas")]
+        public int? Capsulas { get; set; }
+
+        [JsonProperty(PropertyName = "D_Domain_Score2")]
+        public int? DDomainScore { get; set; }
+
+        [JsonProperty(PropertyName = "D_Last_Price_Visit")]
+        public DateTime? DLastPriceVisit { get; set; }
+
+        [JsonProperty(PropertyName = "D_Cant_Visits_Prices")]
+        public int? DCantVisitsPrices { get; set; }
+
+        [JsonProperty(PropertyName = "UTM_Source")]
+        public string UTMSource { get; set; }
+
+        [JsonProperty(PropertyName = "UTM_Medium")]
+        public string UTMMedium { get; set; }
+
+        [JsonProperty(PropertyName = "UTM_Campaign")]
+        public string UTMCampaign { get; set; }
+
+        [JsonProperty(PropertyName = "UTM_Term")]
+        public string UTMTerm { get; set; }
+
+        [JsonProperty(PropertyName = "UTM_Cookie1")]
+        public string UTMCookies { get; set; }
+
+        [JsonProperty(PropertyName = "UTM_Content")]
+        public string UTMContent { get; internal set; }
+
+        [JsonProperty(PropertyName = "D_Primera_Base")]
+        public int DCantSubscribers { get; set; }
+
+        [JsonProperty(PropertyName = "Lim500free")]
+        public string Limit500Free { get; set; }
+
+        [JsonProperty(PropertyName = "Origin_Inbound")]
+        public string OriginInbound { get; set; }
+    }
+}

--- a/Doppler.BillingUser/ExternalServices/Zoho/API/ZohoRefreshTokenResponse.cs
+++ b/Doppler.BillingUser/ExternalServices/Zoho/API/ZohoRefreshTokenResponse.cs
@@ -1,0 +1,19 @@
+using Newtonsoft.Json;
+
+namespace Doppler.BillingUser.ExternalServices.Zoho.API
+{
+    public class ZohoRefreshTokenResponse
+    {
+        [JsonProperty(PropertyName = "access_token")]
+        public string AccessToken { get; set; }
+
+        [JsonProperty(PropertyName = "api_domain")]
+        public string ApiDomain { get; set; }
+
+        [JsonProperty(PropertyName = "expires_in")]
+        public int ExpiresIn { get; set; }
+
+        [JsonProperty(PropertyName = "token_type")]
+        public string TokenType { get; set; }
+    }
+}

--- a/Doppler.BillingUser/ExternalServices/Zoho/API/ZohoResponse.cs
+++ b/Doppler.BillingUser/ExternalServices/Zoho/API/ZohoResponse.cs
@@ -1,0 +1,14 @@
+using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace Doppler.BillingUser.ExternalServices.Zoho.API
+{
+    public class ZohoResponse<T>
+    {
+        [JsonProperty(PropertyName = "data")]
+        public List<T> Data { get; set; }
+
+        [JsonProperty(PropertyName = "info")]
+        public ZohoResponseInfo Info { get; set; }
+    }
+}

--- a/Doppler.BillingUser/ExternalServices/Zoho/API/ZohoResponseInfo.cs
+++ b/Doppler.BillingUser/ExternalServices/Zoho/API/ZohoResponseInfo.cs
@@ -1,0 +1,20 @@
+using Newtonsoft.Json;
+
+
+namespace Doppler.BillingUser.ExternalServices.Zoho.API
+{
+    public class ZohoResponseInfo
+    {
+        [JsonProperty(PropertyName = "per_page")]
+        public int PerPage { get; set; }
+
+        [JsonProperty(PropertyName = "count")]
+        public int Count { get; set; }
+
+        [JsonProperty(PropertyName = "page")]
+        public int Page { get; set; }
+
+        [JsonProperty(PropertyName = "more_records")]
+        public bool MoreRecords { get; set; }
+    }
+}

--- a/Doppler.BillingUser/ExternalServices/Zoho/API/ZohoUpdateModel.cs
+++ b/Doppler.BillingUser/ExternalServices/Zoho/API/ZohoUpdateModel.cs
@@ -1,0 +1,11 @@
+using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace Doppler.BillingUser.ExternalServices.Zoho.API
+{
+    public class ZohoUpdateModel<T>
+    {
+        [JsonProperty(PropertyName = "data")]
+        public List<T> Data { get; set; }
+    }
+}

--- a/Doppler.BillingUser/ExternalServices/Zoho/API/ZohoUpdateResponse.cs
+++ b/Doppler.BillingUser/ExternalServices/Zoho/API/ZohoUpdateResponse.cs
@@ -1,0 +1,11 @@
+using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace Doppler.BillingUser.ExternalServices.Zoho.API
+{
+    public class ZohoUpdateResponse
+    {
+        [JsonProperty(PropertyName = "data")]
+        public List<ZohoUpdateResponseItem> Data { get; set; }
+    }
+}

--- a/Doppler.BillingUser/ExternalServices/Zoho/API/ZohoUpdateResponseDetail.cs
+++ b/Doppler.BillingUser/ExternalServices/Zoho/API/ZohoUpdateResponseDetail.cs
@@ -1,0 +1,23 @@
+using Newtonsoft.Json;
+using System;
+
+namespace Doppler.BillingUser.ExternalServices.Zoho.API
+{
+    public class ZohoUpdateResponseDetail
+    {
+        [JsonProperty(PropertyName = "id")]
+        public string Id { get; set; }
+
+        [JsonProperty(PropertyName = "Modified_Time")]
+        public DateTime ModifiedTime { get; set; }
+
+        [JsonProperty(PropertyName = "Modified_By")]
+        public ZohoUser ModifiedBy { get; set; }
+
+        [JsonProperty(PropertyName = "Created_Time")]
+        public DateTime CreatedTime { get; set; }
+
+        [JsonProperty(PropertyName = "Created_By")]
+        public ZohoUser CreatedBy { get; set; }
+    }
+}

--- a/Doppler.BillingUser/ExternalServices/Zoho/API/ZohoUpdateResponseItem.cs
+++ b/Doppler.BillingUser/ExternalServices/Zoho/API/ZohoUpdateResponseItem.cs
@@ -1,0 +1,19 @@
+using Newtonsoft.Json;
+
+namespace Doppler.BillingUser.ExternalServices.Zoho.API
+{
+    public class ZohoUpdateResponseItem
+    {
+        [JsonProperty(PropertyName = "code")]
+        public string Code { get; set; }
+
+        [JsonProperty(PropertyName = "message")]
+        public string Message { get; set; }
+
+        [JsonProperty(PropertyName = "status")]
+        public string Status { get; set; }
+
+        [JsonProperty(PropertyName = "details")]
+        public ZohoUpdateResponseDetail Details { get; set; }
+    }
+}

--- a/Doppler.BillingUser/ExternalServices/Zoho/API/ZohoUser.cs
+++ b/Doppler.BillingUser/ExternalServices/Zoho/API/ZohoUser.cs
@@ -1,0 +1,16 @@
+using Newtonsoft.Json;
+
+namespace Doppler.BillingUser.ExternalServices.Zoho.API
+{
+    public class ZohoUser
+    {
+        [JsonProperty(PropertyName = "id")]
+        public string Id { get; set; }
+
+        [JsonProperty(PropertyName = "name")]
+        public string Name { get; set; }
+
+        [JsonProperty(PropertyName = "email")]
+        public string Email { get; set; }
+    }
+}

--- a/Doppler.BillingUser/ExternalServices/Zoho/IZohoService.cs
+++ b/Doppler.BillingUser/ExternalServices/Zoho/IZohoService.cs
@@ -1,0 +1,11 @@
+using Doppler.BillingUser.ExternalServices.Zoho.API;
+using System.Threading.Tasks;
+
+namespace Doppler.BillingUser.ExternalServices.Zoho
+{
+    public interface IZohoService
+    {
+        Task<T> SearchZohoEntityAsync<T>(string moduleName, string criteria);
+        Task<ZohoUpdateResponse> UpdateZohoEntityAsync(string body, string entityId, string moduleName);
+    }
+}

--- a/Doppler.BillingUser/ExternalServices/Zoho/ZohoDTO.cs
+++ b/Doppler.BillingUser/ExternalServices/Zoho/ZohoDTO.cs
@@ -1,0 +1,53 @@
+using System;
+
+namespace Doppler.BillingUser.ExternalServices.Zoho
+{
+    public class ZohoDTO
+    {
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+        public string Email { get; set; }
+        public string Company { get; set; }
+        public string Country { get; set; }
+        public string City { get; set; }
+        public string PhoneNumber { get; set; }
+        public string ZipCode { get; set; }
+        public string State { get; set; }
+        public string Street { get; set; }
+        // Specific Doppler Fields
+        public string Doppler { get; set; }
+        public DateTime CreationDate { get; set; }
+        public string Status { get; set; }
+        public DateTime FirstPaymentDate { get; set; }
+        public string DiscountType { get; set; }
+        public string BillingSystem { get; set; }
+        public string Origin { get; set; }
+        public string OriginFirst { get; set; }
+        public DateTime UpgradeDate { get; set; }
+        public int UserId { get; set; }
+        public string PromoCodo { get; set; }
+        public string DiscountTypeDescription { get; set; }
+        public string Source { get; set; }
+        public DateTime? ConfirmationDate { get; set; }
+        public DateTime? LastLogin { get; set; }
+        public int CantLogin { get; set; }
+        public int CantCampaigns { get; set; }
+        public bool ListCreated { get; set; }
+        public string Industry { get; set; }
+        public bool UseDKIM { get; set; }
+        public bool UseIntegration { get; set; }
+        public int CantCapsulas { get; set; }
+        public int DomainScore { get; set; }
+        public DateTime? LastPriceVisitDate { get; set; }
+        public int PriceVisitCount { get; set; }
+        public string UTMSource { get; set; }
+        public string UTMMedium { get; set; }
+        public string UTMCampaign { get; set; }
+        public string UTMTerm { get; set; }
+        public string UTMCookies { get; set; }
+        public string UTMContent { get; set; }
+        public int SubscribersCountFirstImport { get; set; }
+        public bool SubscribersLimitExceed { get; set; }
+        public string OriginInbound { get; set; }
+    }
+}

--- a/Doppler.BillingUser/ExternalServices/Zoho/ZohoService.cs
+++ b/Doppler.BillingUser/ExternalServices/Zoho/ZohoService.cs
@@ -1,0 +1,65 @@
+using Doppler.BillingUser.ExternalServices.Zoho.API;
+using Flurl.Http;
+using Flurl.Http.Configuration;
+using Microsoft.Extensions.Options;
+using System.Threading.Tasks;
+using Tavis.UriTemplates;
+
+namespace Doppler.BillingUser.ExternalServices.Zoho
+{
+    public class ZohoService : IZohoService
+    {
+        private readonly IOptions<ZohoSettings> _options;
+        private readonly IFlurlClient _flurlZohoClient;
+        private readonly IFlurlClient _flurlZohoAuthenticationClient;
+        private string accessToken;
+
+        public ZohoService(
+            IOptions<ZohoSettings> options,
+            IFlurlClientFactory flurlClientFac)
+        {
+            _options = options;
+            _flurlZohoClient = flurlClientFac.Get(_options.Value.BaseUrl);
+            _flurlZohoAuthenticationClient = flurlClientFac.Get(_options.Value.AuthenticationUrl);
+            if (string.IsNullOrEmpty(accessToken))
+            {
+                RefreshTokenAsync();
+            }
+        }
+
+        private async Task RefreshTokenAsync()
+        {
+            var response = await _flurlZohoAuthenticationClient.Request(new UriTemplate($"{_options.Value.AuthenticationUrl}").Resolve())
+              .SetQueryParam("refresh_token", _options.Value.ZohoRefreshToken)
+              .SetQueryParam("grant_type", "refresh_token")
+              .SetQueryParam("scope", "ZohoCRM.modules.ALL,ZohoCRM.users.ALL")
+              .SetQueryParam("client_id", _options.Value.ZohoClientId)
+              .SetQueryParam("client_secret", _options.Value.ZohoClientSecret)
+               .WithHeader("Authorization", $"Zoho-oauthtoken {_options.Value.ZohoRefreshToken}")
+               .PostAsync().ReceiveJson<ZohoRefreshTokenResponse>();
+
+            if (response != null)
+            {
+                accessToken = response.AccessToken;
+            }
+        }
+
+        public async Task<T> SearchZohoEntityAsync<T>(string moduleName, string criteria)
+        {
+            var entity = await _flurlZohoClient.Request(new UriTemplate($"{_options.Value.BaseUrl}{moduleName}/search").Resolve())
+                .SetQueryParam("criteria", criteria)
+                .WithHeader("Authorization", $"Zoho-oauthtoken {accessToken}")
+                .GetJsonAsync<T>();
+
+            return entity;
+        }
+
+        public async Task<ZohoUpdateResponse> UpdateZohoEntityAsync(string body, string entityId, string moduleName)
+        {
+            var entity = await _flurlZohoClient.Request(new UriTemplate($"{_options.Value.BaseUrl}{moduleName}/{entityId}").Resolve())
+                .WithHeader("Authorization", $"Zoho-oauthtoken {accessToken}")
+                .PutStringAsync(body).ReceiveJson<ZohoUpdateResponse>();
+            return entity;
+        }
+    }
+}

--- a/Doppler.BillingUser/ExternalServices/Zoho/ZohoService.cs
+++ b/Doppler.BillingUser/ExternalServices/Zoho/ZohoService.cs
@@ -30,13 +30,13 @@ namespace Doppler.BillingUser.ExternalServices.Zoho
         private async Task RefreshTokenAsync()
         {
             var response = await _flurlZohoAuthenticationClient.Request(new UriTemplate($"{_options.Value.AuthenticationUrl}").Resolve())
-              .SetQueryParam("refresh_token", _options.Value.ZohoRefreshToken)
-              .SetQueryParam("grant_type", "refresh_token")
-              .SetQueryParam("scope", "ZohoCRM.modules.ALL,ZohoCRM.users.ALL")
-              .SetQueryParam("client_id", _options.Value.ZohoClientId)
-              .SetQueryParam("client_secret", _options.Value.ZohoClientSecret)
-               .WithHeader("Authorization", $"Zoho-oauthtoken {_options.Value.ZohoRefreshToken}")
-               .PostAsync().ReceiveJson<ZohoRefreshTokenResponse>();
+                .SetQueryParam("refresh_token", _options.Value.ZohoRefreshToken)
+                .SetQueryParam("grant_type", "refresh_token")
+                .SetQueryParam("scope", "ZohoCRM.modules.ALL,ZohoCRM.users.ALL")
+                .SetQueryParam("client_id", _options.Value.ZohoClientId)
+                .SetQueryParam("client_secret", _options.Value.ZohoClientSecret)
+                .WithHeader("Authorization", $"Zoho-oauthtoken {_options.Value.ZohoRefreshToken}")
+                .PostAsync().ReceiveJson<ZohoRefreshTokenResponse>();
 
             if (response != null)
             {

--- a/Doppler.BillingUser/ExternalServices/Zoho/ZohoSettings.cs
+++ b/Doppler.BillingUser/ExternalServices/Zoho/ZohoSettings.cs
@@ -1,0 +1,12 @@
+namespace Doppler.BillingUser.ExternalServices.Zoho
+{
+    public class ZohoSettings
+    {
+        public bool UseZoho { get; set; }
+        public string BaseUrl { get; set; }
+        public string AuthenticationUrl { get; set; }
+        public string ZohoClientId { get; set; }
+        public string ZohoClientSecret { get; set; }
+        public string ZohoRefreshToken { get; set; }
+    }
+}

--- a/Doppler.BillingUser/Startup.cs
+++ b/Doppler.BillingUser/Startup.cs
@@ -18,6 +18,7 @@ using Doppler.BillingUser.ExternalServices.AccountPlansApi;
 using Doppler.BillingUser.ExternalServices.EmailSender;
 using Doppler.BillingUser.ExternalServices.Slack;
 using Flurl.Http.Configuration;
+using Doppler.BillingUser.ExternalServices.Zoho;
 
 namespace Doppler.BillingUser
 {
@@ -97,6 +98,7 @@ namespace Doppler.BillingUser
             services.AddTransient<IEmailSender, RelayEmailSender>();
             services.AddScoped<ISlackService, SlackService>();
             services.Configure<ZohoSettings>(Configuration.GetSection(nameof(ZohoSettings)));
+            services.AddScoped<IZohoService, ZohoService>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/Doppler.BillingUser/Startup.cs
+++ b/Doppler.BillingUser/Startup.cs
@@ -96,6 +96,7 @@ namespace Doppler.BillingUser
             services.Configure<SlackSettings>(Configuration.GetSection(nameof(SlackSettings)));
             services.AddTransient<IEmailSender, RelayEmailSender>();
             services.AddScoped<ISlackService, SlackService>();
+            services.Configure<ZohoSettings>(Configuration.GetSection(nameof(ZohoSettings)));
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/Doppler.BillingUser/appsettings.Development.json
+++ b/Doppler.BillingUser/appsettings.Development.json
@@ -52,5 +52,13 @@
   "AccountPlansSettings": {
     "CalculateUrlTemplate": "http://localhost:5000/accounts/{accountname}/newplan/{planId}/calculate?discountId={discountId}&promocode={promocode}",
     "GetPromoCodeTemplate": "http://localhost:5000/plans/{planId}/validate/{promocode}"
+  },
+  "ZohoSettings": {
+    "UseZoho": "false",
+    "BaseUrl": "https://www.zohoapis.com/crm/v2/",
+    "AuthenticationUrl": "https://accounts.zoho.com/oauth/v2/token",
+    "ZohoClientId": "REPLACE_FOR_ZOHO_CLIENT_ID",
+    "ZohoClientSecret": "REPLACE_FOR_CLIENT_SECRET",
+    "ZohoRefreshToken": "REPLACE_FOR_REFRESH_TOKEN"
   }
 }

--- a/Doppler.BillingUser/appsettings.int.json
+++ b/Doppler.BillingUser/appsettings.int.json
@@ -16,5 +16,7 @@
       "en": "3b1da2c0-124f-4df9-b588-ef54e8e9aec8"
     },
     "CreditsApprovedAdminTemplateId": "0bc86e98-0e96-4f5f-be67-f62e17b46afa"
+  "ZohoSettings": {
+    "UseZoho": "false"
   }
 }

--- a/Doppler.BillingUser/appsettings.int.json
+++ b/Doppler.BillingUser/appsettings.int.json
@@ -16,7 +16,13 @@
       "en": "3b1da2c0-124f-4df9-b588-ef54e8e9aec8"
     },
     "CreditsApprovedAdminTemplateId": "0bc86e98-0e96-4f5f-be67-f62e17b46afa"
+  },
   "ZohoSettings": {
-    "UseZoho": "false"
+    "UseZoho": "false",
+    "BaseUrl": "REPLACE_FOR_BASE_URL",
+    "AuthenticationUrl": "REPLACE_FOR_AUTHENTICATION_URL",
+    "ZohoClientId": "REPLACE_FOR_ZOHO_CLIENT_ID",
+    "ZohoClientSecret": "REPLACE_FOR_CLIENT_SECRET",
+    "ZohoRefreshToken": "REPLACE_FOR_REFRESH_TOKEN"
   }
 }

--- a/Doppler.BillingUser/appsettings.json
+++ b/Doppler.BillingUser/appsettings.json
@@ -65,5 +65,13 @@
   },
   "SlackSettings": {
     "Url": "[SECRET_KEY]"
+  },
+  "ZohoSettings": {
+    "UseZoho": "true",
+    "BaseUrl": "https://www.zohoapis.com/crm/v2/",
+    "AuthenticationUrl": "https://accounts.zoho.com/oauth/v2/token",
+    "ZohoClientId": "REPLACE_FOR_ZOHO_CLIENT_ID",
+    "ZohoClientSecret": "REPLACE_FOR_CLIENT_SECRET",
+    "ZohoRefreshToken": "REPLACE_FOR_REFRESH_TOKEN"
   }
 }

--- a/Doppler.BillingUser/appsettings.qa.json
+++ b/Doppler.BillingUser/appsettings.qa.json
@@ -16,6 +16,7 @@
       "en": "3b1da2c0-124f-4df9-b588-ef54e8e9aec8"
     },
     "CreditsApprovedAdminTemplateId": "0bc86e98-0e96-4f5f-be67-f62e17b46afa"
+  },
   "ZohoSettings": {
     "UseZoho": "false",
     "BaseUrl": "REPLACE_FOR_BASE_URL",

--- a/Doppler.BillingUser/appsettings.qa.json
+++ b/Doppler.BillingUser/appsettings.qa.json
@@ -16,5 +16,12 @@
       "en": "3b1da2c0-124f-4df9-b588-ef54e8e9aec8"
     },
     "CreditsApprovedAdminTemplateId": "0bc86e98-0e96-4f5f-be67-f62e17b46afa"
+  "ZohoSettings": {
+    "UseZoho": "false",
+    "BaseUrl": "REPLACE_FOR_BASE_URL",
+    "AuthenticationUrl": "REPLACE_FOR_AUTHENTICATION_URL",
+    "ZohoClientId": "REPLACE_FOR_ZOHO_CLIENT_ID",
+    "ZohoClientSecret": "REPLACE_FOR_CLIENT_SECRET",
+    "ZohoRefreshToken": "REPLACE_FOR_REFRESH_TOKEN"
   }
 }


### PR DESCRIPTION
Send update request to zoho api when agreement creation is successfully completed, only if the "UseZoho" flag is true in the app.settings.

**Notes:** 
- If the zoho api request throws an exception, it is caught and a notification is sent to the slack channel.
- Only in production configuration the flag has to be true, for others it must be false.