### PR TITLE
[NO-TICKET] - Set templates id for email notification

### DIFF
--- a/Doppler.BillingUser/appsettings.json
+++ b/Doppler.BillingUser/appsettings.json
@@ -53,10 +53,10 @@
   "EmailNotificationsConfiguration": {
     "AdminEmail": "upgrade@makingsense.com",
     "CreditsApprovedTemplateId": {
-      "es": "TEMPLATE_PROD_ES", //TODO: Replace with correct Id
-      "en": "TEMPLATE_PROD_EN" //TODO: Replace with correct Id
+      "es": "c659d22c-06e2-438e-98b1-51c358a74565",
+      "en": "b4393cdc-6e70-4d36-9877-1e7e31f1bb0d"
     },
-    "CreditsApprovedAdminTemplateId": "TEMPLATE_PROD_ADMIN",
+    "CreditsApprovedAdminTemplateId": "5018971d-f806-4f14-b969-f0cbfa15d2fd",
     "UrlEmailImagesBase": "http://app2.fromdoppler.com/img/Email"
   },
   "AccountPlansSettings": {


### PR DESCRIPTION
Set Relay templates IDs for email notifications when the user do a credit purchase, for production environment.