### PR TITLE
[DAT-779] - Fix issue when the 'BillingCredit' is created

### DIFF
--- a/Doppler.BillingUser/Infrastructure/BillingRepository.cs
+++ b/Doppler.BillingUser/Infrastructure/BillingRepository.cs
@@ -32,7 +32,7 @@ namespace Doppler.BillingUser.Infrastructure
         private const int SourceTypeBuyCreditsId = 3;
         private const int CountryEnumArgentina = 10;
         private const int CurrencyTypeUsd = 0;
-        private const int BillingCreditTypeFreeToIndividual = 4;
+        private const int UpgradeRequest = 1;
 
         public BillingRepository(IDatabaseConnectionFactory connectionFactory,
             IEncryptionService encryptionService,
@@ -708,7 +708,7 @@ SELECT CAST(SCOPE_IDENTITY() AS INT)",
                 @activationDate = now,
                 @extraEmailFee = buyCreditAgreement.BillingCredit.ExtraEmailFee,
                 @totalCreditsQty = buyCreditAgreement.BillingCredit.CreditsQty + (buyCreditAgreement.BillingCredit.ExtraCreditsPromotion ?? 0),
-                @idBillingCreditType = BillingCreditTypeFreeToIndividual,
+                @idBillingCreditType = UpgradeRequest,
                 @ccNumber = buyCreditAgreement.CCNumber,
                 @ccExpMonth = buyCreditAgreement.CCExpMonth,
                 @ccExpYear = buyCreditAgreement.CCExpYear,

--- a/Doppler.BillingUser/Infrastructure/UserRepository.cs
+++ b/Doppler.BillingUser/Infrastructure/UserRepository.cs
@@ -128,7 +128,8 @@ SET
     UTCFirstPayment = @utfFirstPayment,
     IdCurrentBillingCredit = @idCurrentBillingCredit,
     OriginInbound = @originInbound,
-    UpgradePending = @upgradePending
+    UpgradePending = @upgradePending,
+    UTCUpgrade = @utcUpgrade
 WHERE
     IdUser = @idUser;",
             new
@@ -138,7 +139,8 @@ WHERE
                 @cuit = user.Cuit,
                 @utfFirstPayment = user.UTCFirstPayment ?? DateTime.UtcNow,
                 @originInbound = user.OriginInbound,
-                @upgradePending = user.UpgradePending
+                @upgradePending = user.UpgradePending,
+                @utcUpgrade = user.UTCUpgrade ?? DateTime.UtcNow
             });
 
             return result;

--- a/Doppler.BillingUser/Model/UserBillingInformation.cs
+++ b/Doppler.BillingUser/Model/UserBillingInformation.cs
@@ -20,5 +20,6 @@ namespace Doppler.BillingUser.Model
         public string Cuit { get; set; }
         public string OriginInbound { get; set; }
         public bool UpgradePending { get; set; }
+        public DateTime? UTCUpgrade { get; set; }
     }
 }


### PR DESCRIPTION
When the "BillingCredit' is created some information is wrong. For example: Description, Plan and Credits.

Before:

![image](https://user-images.githubusercontent.com/70591946/152808863-2737cca3-24c1-4b5d-b5f2-a67eb592645b.png)

After:

![image](https://user-images.githubusercontent.com/70591946/152809079-245df861-2844-4c61-998e-ad4d44795ad2.png)

**Task:** [DAT-779](https://makingsense.atlassian.net/browse/DAT-779)