### PR TITLE
fix: do not open connection on factory

### DIFF
--- a/Doppler.BillingUser.Test/Utils/ServiceCollectionExtensions.cs
+++ b/Doppler.BillingUser.Test/Utils/ServiceCollectionExtensions.cs
@@ -10,7 +10,7 @@ namespace Doppler.BillingUser.Test.Utils
         public static void SetupConnectionFactory(this IServiceCollection services, DbConnection dbConnection)
         {
             var mockDatabaseConnectionFactory = new Mock<IDatabaseConnectionFactory>();
-            mockDatabaseConnectionFactory.Setup(a => a.GetConnection()).ReturnsAsync(dbConnection);
+            mockDatabaseConnectionFactory.Setup(a => a.GetConnection()).Returns(dbConnection);
             services.AddSingleton(mockDatabaseConnectionFactory.Object);
         }
     }

--- a/Doppler.BillingUser/Infrastructure/BillingRepository.cs
+++ b/Doppler.BillingUser/Infrastructure/BillingRepository.cs
@@ -47,7 +47,7 @@ namespace Doppler.BillingUser.Infrastructure
         }
         public async Task<BillingInformation> GetBillingInformation(string email)
         {
-            using (IDbConnection connection = await _connectionFactory.GetConnection())
+            using (IDbConnection connection = _connectionFactory.GetConnection())
             {
                 var results = await connection.QueryAsync<BillingInformation>(@"
 SELECT
@@ -72,7 +72,7 @@ WHERE
 
         public async Task UpdateBillingInformation(string accountName, BillingInformation billingInformation)
         {
-            using var connection = await _connectionFactory.GetConnection();
+            using var connection = _connectionFactory.GetConnection();
 
             await connection.ExecuteAsync(@"
 UPDATE [User] SET
@@ -100,7 +100,7 @@ WHERE
 
         public async Task<PaymentMethod> GetCurrentPaymentMethod(string username)
         {
-            using var connection = await _connectionFactory.GetConnection();
+            using var connection = _connectionFactory.GetConnection();
 
             var result = await connection.QueryFirstOrDefaultAsync<PaymentMethod>(@"
 
@@ -144,7 +144,7 @@ WHERE
 
         public async Task<EmailRecipients> GetInvoiceRecipients(string accountName)
         {
-            using var connection = await _connectionFactory.GetConnection();
+            using var connection = _connectionFactory.GetConnection();
 
             var user = await connection.QueryFirstOrDefaultAsync<User>(@"
 SELECT
@@ -168,7 +168,7 @@ WHERE
 
         public async Task UpdateInvoiceRecipients(string accountName, string[] emailRecipients, int planId)
         {
-            using var connection = await _connectionFactory.GetConnection();
+            using var connection = _connectionFactory.GetConnection();
 
             await connection.ExecuteAsync(@"
 UPDATE
@@ -188,7 +188,7 @@ WHERE
 
         public async Task<CurrentPlan> GetCurrentPlan(string accountName)
         {
-            using var connection = await _connectionFactory.GetConnection();
+            using var connection = _connectionFactory.GetConnection();
 
             var currentPlan = await connection.QueryFirstOrDefaultAsync<CurrentPlan>(@"
 SELECT
@@ -222,7 +222,7 @@ WHERE
 
         public async Task<bool> UpdateCurrentPaymentMethod(string accountName, PaymentMethod paymentMethod)
         {
-            using var connection = await _connectionFactory.GetConnection();
+            using var connection = _connectionFactory.GetConnection();
 
             var user = await connection.QueryFirstOrDefaultAsync<User>(@"
 SELECT IdUser
@@ -276,7 +276,7 @@ WHERE Email = @email;",
 
         private async Task UpdateUserPaymentMethodByTransfer(User user, PaymentMethod paymentMethod)
         {
-            using var connection = await _connectionFactory.GetConnection();
+            using var connection = _connectionFactory.GetConnection();
 
             await connection.ExecuteAsync(@"
 UPDATE
@@ -304,7 +304,7 @@ WHERE
 
         private async Task UpdateUserPaymentMethod(User user, PaymentMethod paymentMethod)
         {
-            using var connection = await _connectionFactory.GetConnection();
+            using var connection = _connectionFactory.GetConnection();
 
             await connection.ExecuteAsync(@"
 UPDATE
@@ -340,7 +340,7 @@ WHERE
 
         private async Task SendUserDataToSap(string accountName, int planId)
         {
-            using var connection = await _connectionFactory.GetConnection();
+            using var connection = _connectionFactory.GetConnection();
 
             var user = await connection.QueryFirstOrDefaultAsync<User>(@"
 SELECT
@@ -430,7 +430,7 @@ WHERE
 
         private async Task<PaymentMethod> GetPaymentMethodByUserName(string username)
         {
-            using var connection = await _connectionFactory.GetConnection();
+            using var connection = _connectionFactory.GetConnection();
 
             var result = await connection.QueryFirstOrDefaultAsync<PaymentMethod>(@"
 
@@ -467,7 +467,7 @@ WHERE
 
         public async Task<int> CreateAccountingEntriesAsync(AgreementInformation agreementInformation, CreditCard encryptedCreditCard, int userId, UserTypePlanInformation newPlan, string authorizationNumber)
         {
-            var connection = await _connectionFactory.GetConnection();
+            var connection = _connectionFactory.GetConnection();
             var invoiceId = await connection.QueryFirstOrDefaultAsync<int>(@"
 INSERT INTO [dbo].[AccountingEntry]
     ([Date],
@@ -625,7 +625,7 @@ SELECT CAST(SCOPE_IDENTITY() AS INT)",
                 buyCreditAgreement.BillingCredit.SubscribersQty = newUserTypePlan.SubscribersQty;
             }
 
-            var connection = await _connectionFactory.GetConnection();
+            var connection = _connectionFactory.GetConnection();
             var result = await connection.QueryFirstOrDefaultAsync<int>(@"
 INSERT INTO [dbo].[BillingCredits]
     ([Date],
@@ -778,7 +778,7 @@ SELECT CAST(SCOPE_IDENTITY() AS INT)",
                 conceptEnglish = "Monthly Emails Accreditation: " + date.ToString("MMMM", CultureInfo.CreateSpecificCulture("en"));
             }
 
-            var connection = await _connectionFactory.GetConnection();
+            var connection = _connectionFactory.GetConnection();
             var result = await connection.QueryAsync<int>(@"
 INSERT INTO [dbo].[MovementsCredits]
     ([IdUser],
@@ -816,7 +816,7 @@ SELECT CAST(SCOPE_IDENTITY() AS INT)",
 
         public async Task<BillingCredit> GetBillingCredit(int billingCreditId)
         {
-            using var connection = await _connectionFactory.GetConnection();
+            using var connection = _connectionFactory.GetConnection();
             var billingCredit = await connection.QueryFirstOrDefaultAsync<BillingCredit>(@"
 SELECT
     BC.[IdBillingCredit],
@@ -846,7 +846,7 @@ WHERE
 
         public async Task<PlanDiscountInformation> GetPlanDiscountInformation(int discountId)
         {
-            using var connection = await _connectionFactory.GetConnection();
+            using var connection = _connectionFactory.GetConnection();
             var discountInformation = await connection.QueryFirstOrDefaultAsync<PlanDiscountInformation>(@"
 SELECT
     DP.[IdDiscountPlan],
@@ -864,7 +864,7 @@ WHERE
 
         public async Task UpdateUserSubscriberLimitsAsync(int idUser)
         {
-            using var connection = await _connectionFactory.GetConnection();
+            using var connection = _connectionFactory.GetConnection();
             using var dtUserCheckLimits = new DataTable();
             dtUserCheckLimits.Columns.Add(new DataColumn("IdUser", typeof(int)));
 
@@ -880,7 +880,7 @@ WHERE
 
         public async Task<int> ActivateStandBySubscribers(int idUser)
         {
-            using var connection = await _connectionFactory.GetConnection();
+            using var connection = _connectionFactory.GetConnection();
             var result = connection.ExecuteScalar<int>("UserReactivateStandBySubscribers", new { IdUser = idUser }, commandType: CommandType.StoredProcedure);
             return result;
         }

--- a/Doppler.BillingUser/Infrastructure/BillingRepository.cs
+++ b/Doppler.BillingUser/Infrastructure/BillingRepository.cs
@@ -881,7 +881,7 @@ WHERE
         public async Task<int> ActivateStandBySubscribers(int idUser)
         {
             using var connection = _connectionFactory.GetConnection();
-            var result = connection.ExecuteScalar<int>("UserReactivateStandBySubscribers", new { IdUser = idUser }, commandType: CommandType.StoredProcedure);
+            var result = await connection.ExecuteScalarAsync<int>("UserReactivateStandBySubscribers", new { IdUser = idUser }, commandType: CommandType.StoredProcedure);
             return result;
         }
     }

--- a/Doppler.BillingUser/Infrastructure/DatabaseConnectionFactory.cs
+++ b/Doppler.BillingUser/Infrastructure/DatabaseConnectionFactory.cs
@@ -14,15 +14,6 @@ namespace Doppler.BillingUser.Infrastructure
             _connectionString = dopplerDataBaseSettings.Value.GetSqlConnectionString();
         }
 
-        /// <summary>
-        /// Open new connection and return it for use
-        /// </summary>
-        /// <returns></returns>
-        public async Task<IDbConnection> GetConnection()
-        {
-            var cn = new SqlConnection(_connectionString);
-            await cn.OpenAsync();
-            return cn;
-        }
+        public IDbConnection GetConnection() => new SqlConnection(_connectionString);
     }
 }

--- a/Doppler.BillingUser/Infrastructure/IDatabaseConnectionFactory.cs
+++ b/Doppler.BillingUser/Infrastructure/IDatabaseConnectionFactory.cs
@@ -5,6 +5,6 @@ namespace Doppler.BillingUser.Infrastructure
 {
     public interface IDatabaseConnectionFactory
     {
-        Task<IDbConnection> GetConnection();
+        IDbConnection GetConnection();
     }
 }

--- a/Doppler.BillingUser/Infrastructure/PromotionRepository.cs
+++ b/Doppler.BillingUser/Infrastructure/PromotionRepository.cs
@@ -15,7 +15,7 @@ namespace Doppler.BillingUser.Infrastructure
 
         public async Task IncrementUsedTimes(Promotion promocode)
         {
-            using var connection = await _connectionFactory.GetConnection();
+            using var connection = _connectionFactory.GetConnection();
             await connection.ExecuteAsync(@"
 UPDATE
     [Promotions]

--- a/Doppler.BillingUser/Infrastructure/UserRepository.cs
+++ b/Doppler.BillingUser/Infrastructure/UserRepository.cs
@@ -17,7 +17,7 @@ namespace Doppler.BillingUser.Infrastructure
 
         public async Task<UserBillingInformation> GetUserBillingInformation(string accountName)
         {
-            using var connection = await _connectionFactory.GetConnection();
+            using var connection = _connectionFactory.GetConnection();
             var user = await connection.QueryFirstOrDefaultAsync<UserBillingInformation>(@"
 SELECT
     U.IdUser,
@@ -48,7 +48,7 @@ WHERE
 
         public async Task<UserTypePlanInformation> GetUserCurrentTypePlan(int idUser)
         {
-            using var connection = await _connectionFactory.GetConnection();
+            using var connection = _connectionFactory.GetConnection();
             var userTypePlan = await connection.QueryFirstOrDefaultAsync<UserTypePlanInformation>(@"
 SELECT TOP 1
     UTP.[IdUserType]
@@ -72,7 +72,7 @@ ORDER BY
 
         public async Task<CreditCard> GetEncryptedCreditCard(string accountName)
         {
-            using var connection = await _connectionFactory.GetConnection();
+            using var connection = _connectionFactory.GetConnection();
             var encryptedCreditCard = await connection.QueryFirstOrDefaultAsync<CreditCard>(@"
 SELECT
     CCHolderFullName as HolderName,
@@ -95,7 +95,7 @@ WHERE
 
         public async Task<UserTypePlanInformation> GetUserNewTypePlan(int idUserTypePlan)
         {
-            using var connection = await _connectionFactory.GetConnection();
+            using var connection = _connectionFactory.GetConnection();
             var userTypePlan = await connection.QueryFirstOrDefaultAsync<UserTypePlanInformation>(@"
 SELECT
     [IdUserTypePlan],
@@ -119,7 +119,7 @@ WHERE
 
         public async Task<int> UpdateUserBillingCredit(UserBillingInformation user)
         {
-            var connection = await _connectionFactory.GetConnection();
+            var connection = _connectionFactory.GetConnection();
             var result = await connection.ExecuteAsync(@"
 UPDATE
     [dbo].[User]
@@ -150,7 +150,7 @@ WHERE
 
         public async Task<int> GetAvailableCredit(int idUser)
         {
-            using var connection = await _connectionFactory.GetConnection();
+            using var connection = _connectionFactory.GetConnection();
             var partialBalance = await connection.QueryFirstOrDefaultAsync<int>(@"
 SELECT
     PartialBalance
@@ -171,7 +171,7 @@ DESC",
 
         public async Task<User> GetUserInformation(string accountName)
         {
-            using var connection = await _connectionFactory.GetConnection();
+            using var connection = _connectionFactory.GetConnection();
             var user = await connection.QueryFirstOrDefaultAsync<User>(@"
 SELECT
     U.FirstName,


### PR DESCRIPTION
It is not necessary to open the connection explicitly, dapper will do it when a query is executed.
Based in fix (https://github.com/FromDoppler/doppler-html-editor-api/pull/42)