### PR TITLE
[DAT-812] - Update relay account to use leve2support

### DIFF
--- a/Doppler.BillingUser/appsettings.json
+++ b/Doppler.BillingUser/appsettings.json
@@ -43,9 +43,9 @@
   "RelayEmailSenderSettings": {
     "SendTemplateUrlTemplate": "https://api.dopplerrelay.com/accounts/{accountId}/templates/{templateId}/message",
     "ApiKey": "REPLACE_FOR_EMAIL_SENDER_API_KEY",
-    "AccountId": 73,
-    "AccountName": "fromdoppler",
-    "Username": "easla@fromdoppler.com",
+    "AccountId": 8325,
+    "AccountName": "doppler_relay",
+    "Username": "leve2support@fromdoppler.com",
     "FromName": "Doppler",
     "FromAddress": "info@fromdoppler.com",
     "ReplyToAddress": "support@fromdoppler.com"
@@ -53,19 +53,19 @@
   "EmailNotificationsConfiguration": {
     "AdminEmail": "upgrade@makingsense.com",
     "CreditsApprovedTemplateId": {
-      "es": "c659d22c-06e2-438e-98b1-51c358a74565",
-      "en": "b4393cdc-6e70-4d36-9877-1e7e31f1bb0d"
+      "es": "AC7C367E-1FD0-4767-A405-02B37F960B2A",
+      "en": "A97D8942-13F4-4813-AA46-D692A64D5262"
     },
     "UpgradeAccountTemplateId": {
-      "es": "c44cbc5c-ab73-4304-862f-cd46fd175e54",
-      "en": "1474f317-6bca-411e-b764-bf7978056775"
+      "es": "6524e4c6-153c-4b09-a808-b95381cd4ad7",
+      "en": "e047253f-4741-4f87-875f-a430bd564c32"
     },
     "SubscribersPlanPromotionTemplateId": {
-      "es": "fa46c385-d788-4a7c-93ea-47f93f58f958",
-      "en": "64744f8b-6942-4274-9231-4a1eb548f751"
+      "es": "7d2987c5-9775-4d65-b309-8470514a770c",
+      "en": "88ea07dc-2eb0-4600-9691-9eafc97cbc4f"
     },
-    "CreditsApprovedAdminTemplateId": "5018971d-f806-4f14-b969-f0cbfa15d2fd",
-    "UpgradeAccountTemplateAdminTemplateId": "02dcb327-cd22-420f-985b-0e7870f195b8",
+    "CreditsApprovedAdminTemplateId": "4CB25B5E-6BBE-4136-8270-CE24CA6A359C",
+    "UpgradeAccountTemplateAdminTemplateId": "69904622-4a08-47b5-a324-554f437f4794",
     "UrlEmailImagesBase": "http://app2.fromdoppler.com/img/Email"
   },
   "AccountPlansSettings": {


### PR DESCRIPTION
Update relay account to use leve2support.

**Task:** [DAT-812](https://makingsense.atlassian.net/jira/software/projects/DAT/boards/62?selectedIssue=DAT-812)

Notes:
The change of the Relay's account no affect the PROD environment because the emails are not sending at the moment in the PROD environment.
