### PR TITLE
chore: make sync invocation of method explicit

### DIFF
--- a/Doppler.BillingUser/ExternalServices/Zoho/ZohoService.cs
+++ b/Doppler.BillingUser/ExternalServices/Zoho/ZohoService.cs
@@ -23,7 +23,7 @@ namespace Doppler.BillingUser.ExternalServices.Zoho
             _flurlZohoAuthenticationClient = flurlClientFac.Get(_options.Value.AuthenticationUrl);
             if (string.IsNullOrEmpty(accessToken))
             {
-                RefreshTokenAsync();
+                RefreshTokenAsync().RunSynchronously();
             }
         }
 


### PR DESCRIPTION
A very small PR solving a warning about the use of async.
There are more warnig related with deprecated classes but i will solve in another PR
