### PR TITLE
[DAT-950] - Add GetInvoice method

### DIFF
--- a/Doppler.BillingUser/Infrastructure/BillingRepository.cs
+++ b/Doppler.BillingUser/Infrastructure/BillingRepository.cs
@@ -808,6 +808,37 @@ WHERE
             return billingCredit;
         }
 
+        public async Task<AccountingEntry> GetInvoice(int idClient, string authorizationNumber)
+        {
+            var connection = _connectionFactory.GetConnection();
+            var invoice = await connection.QueryFirstOrDefaultAsync<AccountingEntry>(@"
+SELECT
+    AE.[Date],
+    AE.[Amount],
+    AE.[Status],
+    AE.[Source],
+    AE.[AuthorizationNumber],
+    AE.[InvoiceNumber],
+    AE.[AccountEntryType],
+    AE.[AccountingTypeDescription],
+    AE.[IdClient],
+    AE.[IdAccountType],
+    AE.[IdInvoiceBillingType],
+    AE.[IdCurrencyType],
+    AE.[CurrencyRate],
+    AE.[Taxes]
+FROM
+    [dbo].[AccountingEntry] AE
+WHERE
+    idClient = @idClient AND authorizationNumber = @authorizationNumber",
+                new
+                {
+                    @idClient = idClient,
+                    @authorizationNumber = authorizationNumber
+                });
+            return invoice;
+        }
+
         public async Task<PlanDiscountInformation> GetPlanDiscountInformation(int discountId)
         {
             using var connection = _connectionFactory.GetConnection();

--- a/Doppler.BillingUser/Infrastructure/IBillingRepository.cs
+++ b/Doppler.BillingUser/Infrastructure/IBillingRepository.cs
@@ -38,6 +38,8 @@ namespace Doppler.BillingUser.Infrastructure
 
         Task<PaymentMethod> GetPaymentMethodByUserName(string username);
 
+        Task<AccountingEntry> GetInvoice(int idClient, string authorizationNumber);
+
         Task UpdateInvoiceStatus(int id, string status);
 
         Task<int> CreatePaymentEntryAsync(int invoiceId, AccountingEntry paymentEntry);


### PR DESCRIPTION
## Background

We need to create the GetInvoice method to get the invoice by customer and payment ID.

This code is part of the next flow:

```mermaid
sequenceDiagram
	participant MercadoPago
	participant MercadoPagoAPI
	participant BillingUserAPI
	participant BillingUserDB
	MercadoPago ->> BillingUserAPI: POST "/doppler-billing-user/Integration/{accountname}/MercadopagoNotification"
	BillingUserAPI->>MercadoPagoAPI: Get payment
    MercadoPagoAPI->>MercadoPago: Get payment
	MercadoPago->>MercadoPagoAPI: Payment info
	MercadoPagoAPI->>BillingUserAPI: Payment info
	BillingUserAPI->>BillingUserDB: Get invoice (BillingRepo)
	BillingUserDB->>BillingUserAPI: Invoice info
	BillingUserAPI->>BillingUserDB: Update invoice (BillingRepo)
	BillingUserAPI->>BillingUserDB: Get CreditCard (UserRepo)
	BillingUserDB->>BillingUserAPI: CC info
	BillingUserAPI->>BillingUserDB: Create payment (BillingRepo)
	BillingUserDB->>BillingUserAPI: Status info
	BillingUserAPI->>MercadoPago: OkStatusCode
```

Other pull requests that are part of the flow:

- [Create method UpdateInvoiceStatus](https://github.com/FromDoppler/doppler-billing-user/pull/174)
- [Add create payment method](https://github.com/FromDoppler/doppler-billing-user/pull/177)



## Changes

- Added GetInvoice method in BillingRepository