### PR TITLE
[DAT-952] - Add create payment method

### DIFF
--- a/Doppler.BillingUser/Infrastructure/BillingRepository.cs
+++ b/Doppler.BillingUser/Infrastructure/BillingRepository.cs
@@ -962,6 +962,65 @@ SELECT CAST(SCOPE_IDENTITY() AS INT)",
             return invoiceId;
         }
 
+        public async Task<int> CreatePaymentEntryAsync(int invoiceId, AccountingEntry paymentEntry)
+        {
+            var connection = _connectionFactory.GetConnection();
+            var IdAccountingEntry = await connection.QueryFirstOrDefaultAsync<int>(@"
+INSERT INTO [dbo].[AccountingEntry]
+    ([IdClient],
+    [IdInvoice],
+    [Amount],
+    [CCNumber],
+    [CCExpMonth],
+    [CCExpYear],
+    [CCHolderName],
+    [Date],
+    [Source],
+    [AccountingTypeDescription],
+    [IdAccountType],
+    [IdInvoiceBillingType],
+    [AccountEntryType],
+    [AuthorizationNumber],
+    [PaymentEntryType])
+VALUES
+    (@idClient,
+    @idInvoice,
+    @amount,
+    @ccCNumber,
+    @ccExpMonth,
+    @ccExpYear,
+    @ccHolderName,
+    @date,
+    @source,
+    @accountingTypeDescription,
+    @idAccountType,
+    @idInvoiceBillingType,
+    @accountEntryType,
+    @authorizationNumber,
+    @paymentEntryType);
+SELECT CAST(SCOPE_IDENTITY() AS INT)",
+            new
+            {
+                @idClient = paymentEntry.IdClient,
+                @idInvoice = invoiceId,
+                @amount = paymentEntry.Amount,
+                @ccCNumber = paymentEntry.CcCNumber,
+                @ccExpMonth = paymentEntry.CcExpMonth,
+                @ccExpYear = paymentEntry.CcExpYear,
+                @ccHolderName = paymentEntry.CcHolderName,
+                @date = paymentEntry.Date,
+                @source = paymentEntry.Source,
+                @accountingTypeDescription = paymentEntry.AccountingTypeDescription,
+                @idAccountType = paymentEntry.IdAccountType,
+                @idInvoiceBillingType = paymentEntry.IdInvoiceBillingType,
+                @accountEntryType = paymentEntry.AccountEntryType,
+                @authorizationNumber = paymentEntry.AuthorizationNumber,
+                @paymentEntryType = paymentEntry.PaymentEntryType
+            });
+
+            return IdAccountingEntry;
+        }
+
         public async Task UpdateInvoiceStatus(int id, string status)
         {
             var connection = _connectionFactory.GetConnection();

--- a/Doppler.BillingUser/Infrastructure/IBillingRepository.cs
+++ b/Doppler.BillingUser/Infrastructure/IBillingRepository.cs
@@ -39,5 +39,7 @@ namespace Doppler.BillingUser.Infrastructure
         Task<PaymentMethod> GetPaymentMethodByUserName(string username);
 
         Task UpdateInvoiceStatus(int id, string status);
+
+        Task<int> CreatePaymentEntryAsync(int invoiceId, AccountingEntry paymentEntry);
     }
 }


### PR DESCRIPTION
## Background
We need to create a method on `BillingRespository` to insert a paymentEntry into DB to achive the flow at the bottom of this comment.

#### Related Pull Request:
- https://github.com/FromDoppler/doppler-billing-user/pull/176
- https://github.com/FromDoppler/doppler-billing-user/pull/174

### Changes
- _CreatePaymentEntryAsync_ method was added in `BillingRepository`.

#### Diagram of sequence
```mermaid
sequenceDiagram
	participant MercadoPago
	participant MercadoPagoAPI
	participant BillingUserAPI
	participant BillingUserDB
	MercadoPago ->> BillingUserAPI: POST "/doppler-billing-user/Integration/{accountname}/MercadopagoNotification"
	BillingUserAPI->>MercadoPagoAPI: Get payment
    MercadoPagoAPI->>MercadoPago: Get payment
	MercadoPago->>MercadoPagoAPI: Payment info
	MercadoPagoAPI->>BillingUserAPI: Payment info
	BillingUserAPI->>BillingUserDB: Get invoice (BillingRepo)
	BillingUserDB->>BillingUserAPI: Invoice info
	BillingUserAPI->>BillingUserDB: Update invoice (BillingRepo)
	BillingUserAPI->>BillingUserDB: Get CreditCard (UserRepo)
	BillingUserDB->>BillingUserAPI: CC info
	BillingUserAPI->>BillingUserDB: Create payment (BillingRepo)
	BillingUserDB->>BillingUserAPI: Status info
	BillingUserAPI->>MercadoPago: OkStatusCode
```
