### PR TITLE
[DAT-953] - Create Mercadopago Service

### DIFF
--- a/Doppler.BillingUser.Test/MercadoPagoServiceTest.cs
+++ b/Doppler.BillingUser.Test/MercadoPagoServiceTest.cs
@@ -1,0 +1,82 @@
+using Doppler.BillingUser.Authorization;
+using Doppler.BillingUser.ExternalServices.MercadoPagoApi;
+using Flurl.Http;
+using Flurl.Http.Configuration;
+using Flurl.Http.Testing;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using System.Net.Http;
+using Xunit;
+
+namespace Doppler.BillingUser.Test
+{
+    public class MercadoPagoServiceTest
+    {
+        [Fact]
+        public async void Get_payment_by_id_returns_payment_when_mercadopagoapi_response_is_successful()
+        {
+            // Arrange
+            var accountname = "test@example.com";
+            var paymentId = 1;
+            var expectedUrl = $"http://localhost:5000/doppler-mercadopago/accounts/test%40example.com/payment/{paymentId}";
+
+            var factory = new DefaultFlurlClientFactory();
+            var service = new MercadoPagoService(
+                GetMercadoPagoSettingsMock().Object,
+                Mock.Of<IJwtTokenGenerator>(),
+                factory,
+                Mock.Of<ILogger<MercadoPagoService>>());
+
+            using var httpTest = new HttpTest();
+            httpTest.RespondWithJson(new MercadoPagoPayment
+            {
+                Id = 1,
+                Status = "approved",
+                StatusDetail = "Accredited",
+            });
+
+            // Act
+            var payment = await service.GetPaymentById(paymentId, accountname);
+
+            // Assert
+            httpTest
+                .ShouldHaveCalled(expectedUrl)
+                .WithVerb(HttpMethod.Get);
+            Assert.IsType<MercadoPagoPayment>(payment);
+        }
+
+        [Fact]
+        public async void Get_payment_by_id_throws_exception_when_mercadopagoapi_response_is_unsuccessful()
+        {
+            var paymentId = 1;
+            var accountname = "test@example.com";
+            var factory = new DefaultFlurlClientFactory();
+            var service = new MercadoPagoService(
+                GetMercadoPagoSettingsMock().Object,
+                Mock.Of<IJwtTokenGenerator>(),
+                factory,
+                Mock.Of<ILogger<MercadoPagoService>>());
+
+            // Act
+            using var httpTest = new HttpTest();
+            httpTest.RespondWith(status: 500);
+
+            // Assert
+            await Assert.ThrowsAsync<FlurlHttpException>(async () => await service.GetPaymentById(paymentId, accountname));
+        }
+
+
+        private Mock<IOptions<MercadoPagoSettings>> GetMercadoPagoSettingsMock()
+        {
+            var mercadoPagoSettingsMock = new Mock<IOptions<MercadoPagoSettings>>();
+            mercadoPagoSettingsMock.Setup(x => x.Value)
+                .Returns(new MercadoPagoSettings
+                {
+                    MercadoPagoApiUrlTemplate = "http://localhost:5000/doppler-mercadopago/accounts/{accountname}/payment/{id}"
+                });
+
+            return mercadoPagoSettingsMock;
+        }
+    }
+}

--- a/Doppler.BillingUser/ExternalServices/MercadoPagoApi/IMercadoPagoService.cs
+++ b/Doppler.BillingUser/ExternalServices/MercadoPagoApi/IMercadoPagoService.cs
@@ -1,0 +1,6 @@
+namespace Doppler.BillingUser.ExternalServices.MercadoPagoApi
+{
+    public interface IMercadoPagoService
+    {
+    }
+}

--- a/Doppler.BillingUser/ExternalServices/MercadoPagoApi/IMercadoPagoService.cs
+++ b/Doppler.BillingUser/ExternalServices/MercadoPagoApi/IMercadoPagoService.cs
@@ -1,6 +1,9 @@
+using System.Threading.Tasks;
+
 namespace Doppler.BillingUser.ExternalServices.MercadoPagoApi
 {
     public interface IMercadoPagoService
     {
+        Task<MercadoPagoPayment> GetPaymentById(long id, string accountname);
     }
 }

--- a/Doppler.BillingUser/ExternalServices/MercadoPagoApi/MercadoPagoPayment.cs
+++ b/Doppler.BillingUser/ExternalServices/MercadoPagoApi/MercadoPagoPayment.cs
@@ -1,0 +1,9 @@
+namespace Doppler.BillingUser.ExternalServices.MercadoPagoApi
+{
+    public class MercadoPagoPayment
+    {
+        public long Id { get; set; }
+        public string Status { get; set; }
+        public string StatusDetail { get; set; }
+    }
+}

--- a/Doppler.BillingUser/ExternalServices/MercadoPagoApi/MercadoPagoService.cs
+++ b/Doppler.BillingUser/ExternalServices/MercadoPagoApi/MercadoPagoService.cs
@@ -1,14 +1,50 @@
+using Doppler.BillingUser.Authorization;
+using Flurl.Http;
+using Flurl.Http.Configuration;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using System;
+using System.Threading.Tasks;
+using Tavis.UriTemplates;
 
 namespace Doppler.BillingUser.ExternalServices.MercadoPagoApi
 {
     public class MercadoPagoService : IMercadoPagoService
     {
         private readonly IOptions<MercadoPagoSettings> _options;
+        private readonly IJwtTokenGenerator _jwtTokenGenerator;
+        private readonly IFlurlClient _flurlClient;
+        private readonly ILogger<MercadoPagoService> _logger;
 
-        public MercadoPagoService(IOptions<MercadoPagoSettings> options)
+        public MercadoPagoService(
+            IOptions<MercadoPagoSettings> options,
+            IJwtTokenGenerator jwtTokenGenerator,
+            IFlurlClientFactory flurlClientFactory,
+            ILogger<MercadoPagoService> logger)
         {
             _options = options;
+            _jwtTokenGenerator = jwtTokenGenerator;
+            _flurlClient = flurlClientFactory.Get(_options.Value.MercadoPagoApiUrlTemplate);
+            _logger = logger;
+        }
+
+        public async Task<MercadoPagoPayment> GetPaymentById(long id, string accountname)
+        {
+            try
+            {
+                var payment = await _flurlClient.Request(new UriTemplate(_options.Value.MercadoPagoApiUrlTemplate)
+                    .AddParameter("accountname", accountname)
+                    .AddParameter("id", id)
+                    .Resolve())
+                    .WithHeader("Authorization", $"Bearer {_jwtTokenGenerator.GenerateSuperUserJwtToken()}")
+                    .GetJsonAsync<MercadoPagoPayment>();
+                return payment;
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, $"Error to get payment for user: {accountname} with payment ID: {id}");
+                throw;
+            }
         }
     }
 }

--- a/Doppler.BillingUser/ExternalServices/MercadoPagoApi/MercadoPagoService.cs
+++ b/Doppler.BillingUser/ExternalServices/MercadoPagoApi/MercadoPagoService.cs
@@ -1,0 +1,14 @@
+using Microsoft.Extensions.Options;
+
+namespace Doppler.BillingUser.ExternalServices.MercadoPagoApi
+{
+    public class MercadoPagoService : IMercadoPagoService
+    {
+        private readonly IOptions<MercadoPagoSettings> _options;
+
+        public MercadoPagoService(IOptions<MercadoPagoSettings> options)
+        {
+            _options = options;
+        }
+    }
+}

--- a/Doppler.BillingUser/ExternalServices/MercadoPagoApi/MercadoPagoSettings.cs
+++ b/Doppler.BillingUser/ExternalServices/MercadoPagoApi/MercadoPagoSettings.cs
@@ -1,0 +1,7 @@
+namespace Doppler.BillingUser.ExternalServices.MercadoPagoApi
+{
+    public class MercadoPagoSettings
+    {
+        public string MercadoPagoApiUrlTemplate { get; set; }
+    }
+}

--- a/Doppler.BillingUser/Startup.cs
+++ b/Doppler.BillingUser/Startup.cs
@@ -20,6 +20,7 @@ using Doppler.BillingUser.ExternalServices.Slack;
 using Flurl.Http.Configuration;
 using Doppler.BillingUser.ExternalServices.Zoho;
 using Doppler.BillingUser.Services;
+using Doppler.BillingUser.ExternalServices.MercadoPagoApi;
 
 namespace Doppler.BillingUser
 {
@@ -102,6 +103,8 @@ namespace Doppler.BillingUser
             services.AddScoped<IZohoService, ZohoService>();
             services.AddScoped<IEmailTemplatesService, EmailTemplatesService>();
             services.AddScoped<ICurrencyRepository, CurrencyRepository>();
+            services.Configure<MercadoPagoSettings>(Configuration.GetSection(nameof(MercadoPagoSettings)));
+            services.AddScoped<IMercadoPagoService, MercadoPagoService>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/Doppler.BillingUser/appsettings.Development.json
+++ b/Doppler.BillingUser/appsettings.Development.json
@@ -79,5 +79,8 @@
     "ZohoClientId": "REPLACE_FOR_ZOHO_CLIENT_ID",
     "ZohoClientSecret": "REPLACE_FOR_CLIENT_SECRET",
     "ZohoRefreshToken": "REPLACE_FOR_REFRESH_TOKEN"
+  },
+  "MercadoPagoSettings": {
+    "MercadoPagoApiUrlTemplate": "http://localhost:5000/doppler-mercadopago/accounts/{accountname}/payment/{id}"
   }
 }

--- a/Doppler.BillingUser/appsettings.int.json
+++ b/Doppler.BillingUser/appsettings.int.json
@@ -55,5 +55,8 @@
     "SapCreateBusinessPartnerEndpoint": "businesspartner/createorupdatebusinesspartner",
     "SapCreateBillingRequestEndpoint": "billing/createbillingrequest",
     "TimeZoneOffset": "-3"
+  },
+  "MercadoPagoSettings": {
+    "MercadoPagoApiUrlTemplate": "https://apisint.fromdoppler.net/doppler-mercadopago/accounts/{accountname}/payment/{id}"
   }
 }

--- a/Doppler.BillingUser/appsettings.json
+++ b/Doppler.BillingUser/appsettings.json
@@ -98,5 +98,8 @@
     "ZohoClientId": "REPLACE_FOR_ZOHO_CLIENT_ID",
     "ZohoClientSecret": "REPLACE_FOR_CLIENT_SECRET",
     "ZohoRefreshToken": "REPLACE_FOR_REFRESH_TOKEN"
+  },
+  "MercadoPagoSettings": {
+    "MercadoPagoApiUrlTemplate": "https://apis.fromdoppler.com/doppler-mercadopago/accounts/{accountname}/payment/{id}"
   }
 }

--- a/Doppler.BillingUser/appsettings.qa.json
+++ b/Doppler.BillingUser/appsettings.qa.json
@@ -55,5 +55,8 @@
     "SapCreateBusinessPartnerEndpoint": "businesspartner/createorupdatebusinesspartner",
     "SapCreateBillingRequestEndpoint": "billing/createbillingrequest",
     "TimeZoneOffset": "-3"
+  },
+  "MercadoPagoSettings": {
+    "MercadoPagoApiUrlTemplate": "https://apisqa.fromdoppler.net/doppler-mercadopago/accounts/{accountname}/payment/{id}"
   }
 }


### PR DESCRIPTION
## Background
This service is created to use the MercadoPago API. 
It will be used to obtain the payment information, when the status is updated in MP and then it sends a notification with the payment id.

Related Pull Request:
- https://github.com/FromDoppler/doppler-billing-user/pull/176
- https://github.com/FromDoppler/doppler-billing-user/pull/174
- https://github.com/FromDoppler/doppler-billing-user/pull/177

### Changes
- Add MercadoPagoService

### Sequence diagram

```mermaid
sequenceDiagram
	participant MercadoPago
	participant MercadoPagoAPI
	participant BillingUserAPI
	participant BillingUserDB
	MercadoPago ->> BillingUserAPI: POST "/doppler-billing-user/Integration/{accountname}/MercadopagoNotification"
	BillingUserAPI->>MercadoPagoAPI: Get payment
    MercadoPagoAPI->>MercadoPago: Get payment
	MercadoPago->>MercadoPagoAPI: Payment info
	MercadoPagoAPI->>BillingUserAPI: Payment info
	BillingUserAPI->>BillingUserDB: Get invoice (BillingRepo)
	BillingUserDB->>BillingUserAPI: Invoice info
	BillingUserAPI->>BillingUserDB: Update invoice (BillingRepo)
	BillingUserAPI->>BillingUserDB: Get CreditCard (UserRepo)
	BillingUserDB->>BillingUserAPI: CC info
	BillingUserAPI->>BillingUserDB: Create payment (BillingRepo)
	BillingUserDB->>BillingUserAPI: Status info
	BillingUserAPI->>MercadoPago: OkStatusCode
```
