### PR TITLE
[DAT-964] - Add billing account in the notification when any payment failed

### DIFF
--- a/Doppler.BillingUser/ExternalServices/EmailSender/EmailNotificationsConfiguration.cs
+++ b/Doppler.BillingUser/ExternalServices/EmailSender/EmailNotificationsConfiguration.cs
@@ -6,6 +6,7 @@ namespace Doppler.BillingUser.ExternalServices.EmailSender
     {
         public string AdminEmail { get; set; }
         public string CommercialEmail { get; set; }
+        public string BillingEmail { get; set; }
         public Dictionary<string, string> CreditsApprovedTemplateId { get; set; }
         public Dictionary<string, string> UpgradeAccountTemplateId { get; set; }
         public Dictionary<string, string> SubscribersPlanPromotionTemplateId { get; set; }

--- a/Doppler.BillingUser/Services/EmailTemplatesService.cs
+++ b/Doppler.BillingUser/Services/EmailTemplatesService.cs
@@ -234,7 +234,7 @@ namespace Doppler.BillingUser.Services
                         bankMessage,
                         year = DateTime.UtcNow.Year
                     },
-                    to: new[] { _emailSettings.Value.CommercialEmail });
+                    to: new[] { _emailSettings.Value.CommercialEmail, _emailSettings.Value.BillingEmail });
         }
     }
 }

--- a/Doppler.BillingUser/appsettings.int.json
+++ b/Doppler.BillingUser/appsettings.int.json
@@ -12,6 +12,7 @@
   "EmailNotificationsConfiguration": {
     "AdminEmail": "jhoffman@makingsense.com",
     "CommercialEmail": "jhoffman@makingsense.com",
+    "BillingEmail": "dopplerintegrationint@mailinator.com",
     "CreditsApprovedTemplateId": {
       "es": "a8d0afca-f8e8-4ef0-be1a-1ec3edacbe51",
       "en": "3b1da2c0-124f-4df9-b588-ef54e8e9aec8"

--- a/Doppler.BillingUser/appsettings.json
+++ b/Doppler.BillingUser/appsettings.json
@@ -53,6 +53,7 @@
   "EmailNotificationsConfiguration": {
     "AdminEmail": "upgrade@makingsense.com",
     "CommercialEmail": "dopplerinbound@makingsense.com",
+    "BillingEmail": "billing@fromdoppler.com",
     "CreditsApprovedTemplateId": {
       "es": "AC7C367E-1FD0-4767-A405-02B37F960B2A",
       "en": "A97D8942-13F4-4813-AA46-D692A64D5262"

--- a/Doppler.BillingUser/appsettings.qa.json
+++ b/Doppler.BillingUser/appsettings.qa.json
@@ -12,6 +12,7 @@
   "EmailNotificationsConfiguration": {
     "AdminEmail": "dopplerintegration@mailinator.com",
     "CommercialEmail": "dopplerintegration@mailinator.com",
+    "BillingEmail": "dopplerintegration@mailinator.com",
     "CreditsApprovedTemplateId": {
       "es": "a8d0afca-f8e8-4ef0-be1a-1ec3edacbe51",
       "en": "3b1da2c0-124f-4df9-b588-ef54e8e9aec8"


### PR DESCRIPTION
Add billing account in the notification when any payment failed

**Task:** [DAT-964](https://makingsense.atlassian.net/jira/software/projects/DAT/boards/62?selectedIssue=DAT-964)