### PR TITLE
[DOM-390] - max subscribers zero on upgrade

### DIFF
--- a/Doppler.BillingUser/Infrastructure/UserRepository.cs
+++ b/Doppler.BillingUser/Infrastructure/UserRepository.cs
@@ -33,7 +33,8 @@ SELECT
     U.UTCFirstPayment,
     U.OriginInbound,
     U.CUIT,
-    U.IdCurrentBillingCredit
+    U.IdCurrentBillingCredit,
+    U.MaxSubscribers
 FROM
     [User] U
     INNER JOIN


### PR DESCRIPTION
## Summary
Bug fixed when upgrading an account with a free plan. Now keeps the old MaxSubscribers number if the new plan has SubscribersQty set in NULL.

Jira task [here](https://makingsense.atlassian.net/browse/DOM-390).