### PR TITLE
[DAT-1226] - Add last four digits in the error message when first data throws an error

### DIFF
--- a/Doppler.BillingUser.Test/PostAgreementTest.cs
+++ b/Doppler.BillingUser.Test/PostAgreementTest.cs
@@ -702,6 +702,7 @@ namespace Doppler.BillingUser.Test
                     services.AddSingleton(accountServiceMock.Object);
                     services.AddSingleton(Mock.Of<ISlackService>());
                     services.AddSingleton(Mock.Of<IUserPaymentHistoryRepository>());
+                    services.AddSingleton(Mock.Of<IEncryptionService>());
                 });
 
             }).CreateClient(new WebApplicationFactoryClientOptions());
@@ -769,6 +770,7 @@ namespace Doppler.BillingUser.Test
                     services.AddSingleton(accountServiceMock.Object);
                     services.AddSingleton(Mock.Of<ISlackService>());
                     services.AddSingleton(Mock.Of<IUserPaymentHistoryRepository>());
+                    services.AddSingleton(Mock.Of<IEncryptionService>());
                 });
 
             }).CreateClient(new WebApplicationFactoryClientOptions());
@@ -1303,6 +1305,9 @@ namespace Doppler.BillingUser.Test
             accountServiceMock.Setup(x => x.IsValidTotal(It.IsAny<string>(), It.IsAny<AgreementInformation>()))
                 .ReturnsAsync(true);
 
+            var encryptionServiceMock = new Mock<IEncryptionService>();
+            encryptionServiceMock.Setup(x => x.DecryptAES256(It.IsAny<string>())).Returns("12345");
+
             var factory = _factory.WithWebHostBuilder(builder =>
             {
                 builder.ConfigureTestServices(services =>
@@ -1312,6 +1317,7 @@ namespace Doppler.BillingUser.Test
                     services.AddSingleton(accountServiceMock.Object);
                     services.AddSingleton(GetSlackSettingsMock().Object);
                     services.AddSingleton(Mock.Of<IUserPaymentHistoryRepository>());
+                    services.AddSingleton(encryptionServiceMock.Object);
                 });
 
             });


### PR DESCRIPTION
Add last four digits in the error message when first data throws an error.

**Error message:**

- Failed at updating payment method for user test_show_credit_card_slack_error_int_1@mailinator.com with last four digits of the credit card: 4444. Exception DeclinedPaymentTransaction - Invalid Credit Card Number.

- Failed at creating new agreement for user test_show_credit_card_slack_error_int_1@mailinator.com with last four digits of the credit card: 1111. Exception DeclinedPaymentTransaction - Invalid Expiration Date [Bank]

**Task:**[DAT-1226](https://makingsense.atlassian.net/jira/software/projects/DAT/boards/62?selectedIssue=DAT-1226)