### PR TITLE
[DAT-1378] - add email to declined mercadopago payment email

### DIFF
--- a/Doppler.BillingUser/Services/EmailTemplatesService.cs
+++ b/Doppler.BillingUser/Services/EmailTemplatesService.cs
@@ -469,6 +469,7 @@ namespace Doppler.BillingUser.Services
                     {
                         urlImagesBase = _emailSettings.Value.UrlEmailImagesBase,
                         userId = user.IdUser,
+                        userEmail = accountname,
                         motivoError = paymentStatusDetails,
                         year = DateTime.UtcNow.Year
                     },


### PR DESCRIPTION
[DAT-1378](https://makingsense.atlassian.net/browse/DAT-1378)

Add email field for the DECLINEDMERCADOPAGOPAYMENTUPSELLINGADMIN and DECLINEDMERCADOPAGOPAYMENTUPGRADEADMIN templates

[DAT-1378]: https://makingsense.atlassian.net/browse/DAT-1378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ