### PR TITLE
[No-Ticket] Use FlurlClient instead of SOAP Client

### DIFF
--- a/Doppler.BillingUser/Utils/XmlSerializer.cs
+++ b/Doppler.BillingUser/Utils/XmlSerializer.cs
@@ -1,0 +1,38 @@
+using System.IO;
+using System.Xml;
+
+namespace Doppler.BillingUser.Utils
+{
+    public static class XmlSerializer
+    {
+        public static string ToXmlString<T>(T model, XmlWriterSettings settings)
+        {
+            var xmlSerializer = new System.Xml.Serialization.XmlSerializer(typeof(T));
+
+            using (var stream = new StringWriter())
+            using (var writer = XmlWriter.Create(stream, settings))
+            {
+                xmlSerializer.Serialize(writer, model);
+                return stream.ToString();
+            }
+        }
+
+        public static string ToXmlString<T>(T model)
+        {
+            return ToXmlString(model, new XmlWriterSettings
+            {
+                Indent = true,
+                OmitXmlDeclaration = true
+            });
+        }
+
+        public static T FromXmlString<T>(string xml)
+        {
+            var xmlSerializer = new System.Xml.Serialization.XmlSerializer(typeof(T));
+            using (var stringreader = new StringReader(xml))
+            {
+                return (T)xmlSerializer.Deserialize(stringreader);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Use FlurlClient instead of SOAP Client when call FirstData because using SOAP Client we have an error:

Exception ClientPaymentTransactionError - The content type text/plain; charset=UTF-8 of the response message does not match the content type of the binding (text/xml; charset=utf-8). If using a custom encoder, be sure that the IsContentTypeSupported method is implemented properly. The first 1024 bytes of the response were: '<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Body s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><q2:Transaction id="id1" xsi:type="q2:Transaction" xmlns:q2="http://secure2.e-xact.com/vplug-in/transaction/rpc-enc/encodedTypes" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ExactID xsi:type="xsd:string">F63330-33</ExactID><Password xsi:type="xsd:string">plWuWHy93wokzTAdiD031Yg9YbH6Oeb7</Password><Transaction_Type xsi:type="xsd:string">01</Transaction_Type><DollarAmount xsi:type="xsd:string">0</DollarAmount><Card_Number xsi:type="xsd:string">4345591010445751</Card_Number><Expiry_Date xsi:type="xsd:string">0525</Expiry_Date><CardHoldersName xsi:type="xsd:string">Giovanni Contreras</CardHoldersName><CVDCode xsi:type="xsd:string">559</CVDCode><CVD_Presence_Ind xsi:type="xsd:string">1</CVD_Presence_Ind><Reference_No xsi:type="xsd:string">Doppler Email Marketing</Reference_No><Customer_Ref xsi:type="xsd:string">384412</Customer_Ref></q2:Transaction><q1:SendAndCommitResponse'..