### PR TITLE
fix: send tax regime description

### DIFF
--- a/Doppler.BillingUser/Services/EmailTemplatesService.cs
+++ b/Doppler.BillingUser/Services/EmailTemplatesService.cs
@@ -356,7 +356,7 @@ namespace Doppler.BillingUser.Services
                         isPaymentWayTransfer = user.PaymentWay == "TRANSFER",
                         bankName = user.BankName,
                         bankAccount = user.BankAccount,
-                        taxRegime = user.TaxRegime,
+                        taxRegime = user.TaxRegimeDescription,
                         billingEmails = userInformation.BillingEmails,
                         isIndividualPlan = newPlan.IdUserType == UserTypeEnum.INDIVIDUAL,
                         isMonthlyPlan = newPlan.IdUserType == UserTypeEnum.MONTHLY,


### PR DESCRIPTION
Fix bug tax regime value in the email was only the tax regime Id instead of the description