### PR TITLE
[DAT-1527] - Include ClientPaymentTransactionError status in PaymentStatusEnum

### DIFF
--- a/Doppler.BillingUser.Test/ReprocessTest.cs
+++ b/Doppler.BillingUser.Test/ReprocessTest.cs
@@ -95,7 +95,7 @@ namespace Doppler.BillingUser.Test
             var authorizatioNumber = "LLLTD222";
 
             var billingRepositoryMock = new Mock<IBillingRepository>();
-            billingRepositoryMock.Setup(x => x.GetInvoices(userId, PaymentStatusEnum.DeclinedPaymentTransaction))
+            billingRepositoryMock.Setup(x => x.GetInvoices(userId, PaymentStatusEnum.DeclinedPaymentTransaction, PaymentStatusEnum.ClientPaymentTransactionError))
                 .ReturnsAsync(new List<AccountingEntry>());
 
             var userRepositoryMock = new Mock<IUserRepository>();
@@ -166,7 +166,7 @@ namespace Doppler.BillingUser.Test
             var billingRepositoryMock = new Mock<IBillingRepository>();
             billingRepositoryMock.Setup(x => x.CreateAccountingEntriesAsync(It.IsAny<AccountingEntry>(), It.IsAny<AccountingEntry>())).ReturnsAsync(1);
             billingRepositoryMock.Setup(x => x.GetPaymentMethodByUserName(It.IsAny<string>())).ReturnsAsync(currentPaymentMethod);
-            billingRepositoryMock.Setup(x => x.GetInvoices(userId, PaymentStatusEnum.DeclinedPaymentTransaction))
+            billingRepositoryMock.Setup(x => x.GetInvoices(userId, PaymentStatusEnum.DeclinedPaymentTransaction, PaymentStatusEnum.ClientPaymentTransactionError))
                 .ReturnsAsync(new List<AccountingEntry>()
                 {
                     new AccountingEntry() { Amount = 1, Status = PaymentStatusEnum.DeclinedPaymentTransaction }

--- a/Doppler.BillingUser/ApiModels/PaymentStatusApiEnum.cs
+++ b/Doppler.BillingUser/ApiModels/PaymentStatusApiEnum.cs
@@ -9,6 +9,7 @@ namespace Doppler.BillingUser.ApiModels
         Approved,
         Pending,
         Declined,
-        Failed
+        Failed,
+        ClientFailed
     }
 }

--- a/Doppler.BillingUser/Controllers/BillingController.cs
+++ b/Doppler.BillingUser/Controllers/BillingController.cs
@@ -360,7 +360,7 @@ namespace Doppler.BillingUser.Controllers
 
             var user = await _userRepository.GetUserInformation(accountname);
 
-            var invoices = await _billingRepository.GetInvoices(user.IdUser, PaymentStatusEnum.DeclinedPaymentTransaction);
+            var invoices = await _billingRepository.GetInvoices(user.IdUser, PaymentStatusEnum.DeclinedPaymentTransaction, PaymentStatusEnum.ClientPaymentTransactionError);
 
             if (invoices.Count == 0)
             {

--- a/Doppler.BillingUser/Enums/PaymentStatusEnum.cs
+++ b/Doppler.BillingUser/Enums/PaymentStatusEnum.cs
@@ -13,6 +13,8 @@ namespace Doppler.BillingUser.Enums
         [Description("FailedPaymentTransaction")]
         FailedPaymentTransaction,
         [Description("Credit Note Generated")]
-        CreditNoteGenerated
+        CreditNoteGenerated,
+        [Description("ClientPaymentTransactionError")]
+        ClientPaymentTransactionError
     }
 }

--- a/Doppler.BillingUser/Mappers/PaymentStatus/PaymentStatusMapper.cs
+++ b/Doppler.BillingUser/Mappers/PaymentStatus/PaymentStatusMapper.cs
@@ -15,6 +15,7 @@ namespace Doppler.BillingUser.Mappers.PaymentStatus
                 PaymentStatusApiEnum.Pending => PaymentStatusEnum.Pending,
                 PaymentStatusApiEnum.Declined => PaymentStatusEnum.DeclinedPaymentTransaction,
                 PaymentStatusApiEnum.Failed => PaymentStatusEnum.FailedPaymentTransaction,
+                PaymentStatusApiEnum.ClientFailed => PaymentStatusEnum.ClientPaymentTransactionError,
                 _ => throw new Exception()
             };
         }
@@ -28,6 +29,7 @@ namespace Doppler.BillingUser.Mappers.PaymentStatus
                 PaymentStatusEnum.DeclinedPaymentTransaction => PaymentStatusApiEnum.Declined,
                 PaymentStatusEnum.FailedPaymentTransaction => PaymentStatusApiEnum.Failed,
                 PaymentStatusEnum.CreditNoteGenerated => PaymentStatusApiEnum.Approved,
+                PaymentStatusEnum.ClientPaymentTransactionError => PaymentStatusApiEnum.ClientFailed,
                 _ => throw new Exception()
             };
         }


### PR DESCRIPTION
Add ClientPaymentTransactionError status in PaymentStatusEnum and include it to get invoices.

**Task:** [DAT-1527](https://makingsense.atlassian.net/jira/software/projects/DAT/boards/62?selectedIssue=DAT-1527)

[DAT-1527]: https://makingsense.atlassian.net/browse/DAT-1527?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ